### PR TITLE
Add iterative fitburst fitting support

### DIFF
--- a/flits/analysis/fitting/fitburst_adapter.py
+++ b/flits/analysis/fitting/fitburst_adapter.py
@@ -92,6 +92,10 @@ class FitburstRequestConfig:
         estimate per-channel weights from the fitted data window. When
         ``weighted_fit`` is true and this is omitted, the adapter derives
         weights from the current off-pulse bins.
+    iterations
+        Number of consecutive fitburst optimizer runs. After each successful
+        run, the next run is initialized from the previous best-fit
+        parameters.
     bounds
         Optional serialized bounds payload. This field is preserved in request
         dictionaries for API compatibility, but the current adapter does not
@@ -108,6 +112,7 @@ class FitburstRequestConfig:
     initial_parameters: dict[str, list[float]] | None = None
     weighted_fit: bool = False
     weight_range: list[int] | None = None
+    iterations: int = 1
     bounds: dict[str, list[tuple[float, float]]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -118,6 +123,7 @@ class FitburstRequestConfig:
             "initial_parameters": self.initial_parameters,
             "weighted_fit": bool(self.weighted_fit),
             "weight_range": None if self.weight_range is None else [int(value) for value in self.weight_range],
+            "iterations": _coerce_iterations(self.iterations),
             "bounds": self.bounds,
         }
 
@@ -136,6 +142,7 @@ class FitburstRequestConfig:
             initial_parameters=payload.get("initial_parameters"),
             weighted_fit=_coerce_bool(payload.get("weighted_fit"), default=False),
             weight_range=_coerce_weight_range(payload.get("weight_range")),
+            iterations=_coerce_iterations(payload.get("iterations")),
             bounds=payload.get("bounds"),
         )
 
@@ -237,10 +244,18 @@ def fit_scattering_selected_band(
     For multi-component fits, inspect ``diagnostics.bestfit_parameters`` for
     the full fitburst parameter arrays.
     """
+    if config is None:
+        config = FitburstRequestConfig()
+    fit_iterations = _coerce_iterations(config.iterations)
+
     if SpectrumModeler is None or LSFitter is None:
         return _failed_result(
             status="fitburst_unavailable",
             message="fitburst is not available in the active Python environment.",
+            component_count=config.num_components,
+            fixed_parameters=config.fixed_parameters,
+            fit_iterations_requested=fit_iterations,
+            fit_iterations_completed=0,
         )
 
     data = np.asarray(selected_band, dtype=float)
@@ -249,11 +264,22 @@ def fit_scattering_selected_band(
     offpulse_bins = np.asarray(offpulse_bins, dtype=int)
 
     if data.ndim != 2 or data.shape[0] == 0 or data.shape[1] == 0:
-        return _failed_result(status="insufficient_data", message="No selected-band data are available for fitting.")
+        return _failed_result(
+            status="insufficient_data",
+            message="No selected-band data are available for fitting.",
+            component_count=config.num_components,
+            fixed_parameters=config.fixed_parameters,
+            fit_iterations_requested=fit_iterations,
+            fit_iterations_completed=0,
+        )
     if data.shape[1] < MIN_FIT_TIME_BINS:
         return _failed_result(
             status="insufficient_time_bins",
             message=f"At least {MIN_FIT_TIME_BINS} time bins are required for scattering fits.",
+            component_count=config.num_components,
+            fixed_parameters=config.fixed_parameters,
+            fit_iterations_requested=fit_iterations,
+            fit_iterations_completed=0,
         )
 
     normalized_data, good_freq = _normalize_dynamic_spectrum(data, offpulse_bins)
@@ -262,6 +288,10 @@ def fit_scattering_selected_band(
         return _failed_result(
             status="insufficient_channels",
             message=f"At least {MIN_FIT_CHANNELS} unmasked channels are required for scattering fits.",
+            component_count=config.num_components,
+            fixed_parameters=config.fixed_parameters,
+            fit_iterations_requested=fit_iterations,
+            fit_iterations_completed=0,
         )
 
 
@@ -273,14 +303,15 @@ def fit_scattering_selected_band(
         return _failed_result(
             status="insufficient_signal",
             message="The selected event window does not contain a stable signal for fitting.",
+            component_count=config.num_components,
+            fixed_parameters=config.fixed_parameters,
+            fit_iterations_requested=fit_iterations,
+            fit_iterations_completed=0,
         )
 
     if peak_rel_bin is None:
         peak_rel_bin = int(event_rel_start + np.nanargmax(event_slice))
     peak_rel_bin = max(0, min(int(peak_rel_bin), data.shape[1] - 1))
-
-    if config is None:
-        config = FitburstRequestConfig()
 
     initial_parameters = _initial_parameters(
         normalized_data=normalized_data,
@@ -326,41 +357,73 @@ def fit_scattering_selected_band(
         num_components=config.num_components,
         is_dedispersed=True,
     )
-    model.update_parameters(initial_parameters)
-    fitter = LSFitter(
-        fit_data,
-        model,
-        good_freq=good_freq,
-        weighted_fit=weighted_fit and custom_weights is None,
-        weight_range=weight_range if weighted_fit and custom_weights is None else None,
-    )
-    if custom_weights is not None:
-        fitter.weights = custom_weights
-    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-        fitter.fix_parameter(config.fixed_parameters)
-        fitter.fit()
+    current_parameters = _copy_parameter_dict(initial_parameters)
+    completed_iterations = 0
+    fitter: Any | None = None
+    results: Any | None = None
+    fit_statistics: dict[str, object] = {}
+    bestfit_uncertainties: dict[str, list[float] | None] = {}
+    fit_parameters: list[str] = []
 
-    results = getattr(fitter, "results", None)
-    if results is None or not getattr(results, "success", False):
-        message = None
-        if results is not None:
-            message = str(getattr(results, "message", "") or "").strip() or None
+    for _iteration_index in range(fit_iterations):
+        model.update_parameters(current_parameters)
+        fitter = LSFitter(
+            fit_data,
+            model,
+            good_freq=good_freq,
+            weighted_fit=weighted_fit and custom_weights is None,
+            weight_range=weight_range if weighted_fit and custom_weights is None else None,
+        )
+        if custom_weights is not None:
+            fitter.weights = custom_weights
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            fitter.fix_parameter(config.fixed_parameters)
+            fitter.fit()
+
+        results = getattr(fitter, "results", None)
+        if results is None or not getattr(results, "success", False):
+            message = None
+            if results is not None:
+                message = str(getattr(results, "message", "") or "").strip() or None
+            return _failed_result(
+                status="fit_failed",
+                message=message or "fitburst could not converge for the current selection.",
+                initial_parameters=initial_parameters,
+                bestfit_parameters=current_parameters if completed_iterations > 0 else {},
+                fit_statistics=getattr(fitter, "fit_statistics", {}),
+                fit_parameters=list(getattr(fitter, "fit_parameters", [])),
+                fixed_parameters=config.fixed_parameters,
+                component_count=config.num_components,
+                weighted_fit=weighted_fit,
+                weight_range=weight_range,
+                weight_range_basis=weight_range_basis,
+                fit_iterations_requested=fit_iterations,
+                fit_iterations_completed=completed_iterations,
+            )
+
+        fit_statistics = dict(getattr(fitter, "fit_statistics", {}))
+        bestfit_parameters = dict(fit_statistics.get("bestfit_parameters") or {})
+        bestfit_uncertainties = _copy_parameter_dict(dict(fit_statistics.get("bestfit_uncertainties") or {}))
+        fit_parameters = list(getattr(fitter, "fit_parameters", []))
+        current_parameters = _merge_parameter_dicts(current_parameters, bestfit_parameters)
+        completed_iterations += 1
+
+    if results is None:
         return _failed_result(
             status="fit_failed",
-            message=message or "fitburst could not converge for the current selection.",
+            message="fitburst could not converge for the current selection.",
             initial_parameters=initial_parameters,
-            fit_statistics=getattr(fitter, "fit_statistics", {}),
+            fit_parameters=fit_parameters,
+            fixed_parameters=config.fixed_parameters,
+            component_count=config.num_components,
             weighted_fit=weighted_fit,
             weight_range=weight_range,
             weight_range_basis=weight_range_basis,
+            fit_iterations_requested=fit_iterations,
+            fit_iterations_completed=completed_iterations,
         )
 
-    fit_statistics = dict(getattr(fitter, "fit_statistics", {}))
-    bestfit_parameters = dict(fit_statistics.get("bestfit_parameters") or {})
-    bestfit_uncertainties = dict(fit_statistics.get("bestfit_uncertainties") or {})
-    fit_parameters = list(getattr(fitter, "fit_parameters", []))
-    full_best_parameters = dict(initial_parameters)
-    full_best_parameters.update(bestfit_parameters)
+    full_best_parameters = current_parameters
     
     model.update_parameters(full_best_parameters)
     model_dynamic_spectrum = np.asarray(model.compute_model(data=fit_data), dtype=float)
@@ -407,6 +470,8 @@ def fit_scattering_selected_band(
         weighted_fit=weighted_fit,
         weight_range=weight_range,
         weight_range_basis=weight_range_basis,
+        fit_iterations_requested=fit_iterations,
+        fit_iterations_completed=completed_iterations,
         initial_parameters=initial_parameters,
         bestfit_parameters=full_best_parameters,
         bestfit_uncertainties=bestfit_uncertainties,
@@ -584,6 +649,14 @@ def _coerce_bool(value: Any, *, default: bool = False) -> bool:
     return bool(value)
 
 
+def _coerce_iterations(value: Any) -> int:
+    try:
+        iterations = int(value)
+    except (TypeError, ValueError):
+        return 1
+    return max(1, iterations)
+
+
 def _coerce_weight_range(values: Any, num_time: int | None = None) -> list[int] | None:
     if values is None:
         return None
@@ -630,6 +703,32 @@ def _offpulse_channel_weights(
     return weights, [int(bins[0]), int(bins[-1] + 1)]
 
 
+def _copy_parameter_dict(
+    parameters: dict[str, Any],
+) -> dict[str, list[float] | None]:
+    copied: dict[str, list[float] | None] = {}
+    for key, values in parameters.items():
+        if values is None:
+            copied[str(key)] = None
+            continue
+        try:
+            value_array = np.asarray(values, dtype=float).ravel()
+        except (TypeError, ValueError):
+            copied[str(key)] = []
+            continue
+        copied[str(key)] = [float(value) for value in value_array]
+    return copied
+
+
+def _merge_parameter_dicts(
+    base: dict[str, Any],
+    updates: dict[str, Any],
+) -> dict[str, list[float] | None]:
+    merged = _copy_parameter_dict(base)
+    merged.update(_copy_parameter_dict(updates))
+    return merged
+
+
 def _parameter_value(parameters: dict[str, list[float] | None], key: str) -> float | None:
     values = parameters.get(key)
     if not values:
@@ -671,24 +770,32 @@ def _failed_result(
     status: str,
     message: str | None,
     initial_parameters: dict[str, list[float]] | None = None,
+    bestfit_parameters: dict[str, list[float] | None] | None = None,
     fit_statistics: dict[str, object] | None = None,
+    fit_parameters: list[str] | None = None,
+    fixed_parameters: list[str] | None = None,
+    component_count: int = 1,
     weighted_fit: bool | None = None,
     weight_range: list[int] | None = None,
     weight_range_basis: str | None = None,
+    fit_iterations_requested: int | None = None,
+    fit_iterations_completed: int | None = None,
 ) -> FitburstScatteringResult:
     """Return a structured failure result with empty diagnostic arrays."""
     diagnostics = ScatteringFitDiagnostics(
         status=status,
         message=message,
         fitter="fitburst" if SpectrumModeler is not None and LSFitter is not None else None,
-        component_count=1,
-        fit_parameters=list(FIT_PARAMETERS),
-        fixed_parameters=list(FIXED_PARAMETERS),
+        component_count=component_count,
+        fit_parameters=list(FIT_PARAMETERS if fit_parameters is None else fit_parameters),
+        fixed_parameters=list(FIXED_PARAMETERS if fixed_parameters is None else fixed_parameters),
         weighted_fit=weighted_fit,
         weight_range=weight_range,
         weight_range_basis=weight_range_basis,
+        fit_iterations_requested=fit_iterations_requested,
+        fit_iterations_completed=fit_iterations_completed,
         initial_parameters=initial_parameters or {},
-        bestfit_parameters={},
+        bestfit_parameters=bestfit_parameters or {},
         bestfit_uncertainties={},
         fit_statistics=_sanitize_fit_statistics(fit_statistics or {}),
         freq_axis_mhz=np.array([], dtype=float),

--- a/flits/models.py
+++ b/flits/models.py
@@ -1337,6 +1337,8 @@ class ScatteringFitDiagnostics:
     weighted_fit: bool | None = None
     weight_range: list[int] | None = None
     weight_range_basis: str | None = None
+    fit_iterations_requested: int | None = None
+    fit_iterations_completed: int | None = None
     initial_parameters: dict[str, list[float] | None] = field(default_factory=dict)
     bestfit_parameters: dict[str, list[float] | None] = field(default_factory=dict)
     bestfit_uncertainties: dict[str, list[float] | None] = field(default_factory=dict)
@@ -1377,6 +1379,8 @@ class ScatteringFitDiagnostics:
             "weighted_fit": _bool_or_none(self.weighted_fit),
             "weight_range": None if self.weight_range is None else [int(value) for value in self.weight_range],
             "weight_range_basis": self.weight_range_basis,
+            "fit_iterations_requested": _int_or_none(self.fit_iterations_requested),
+            "fit_iterations_completed": _int_or_none(self.fit_iterations_completed),
             "initial_parameters": _jsonable_parameter_dict(self.initial_parameters),
             "bestfit_parameters": _jsonable_parameter_dict(self.bestfit_parameters),
             "bestfit_uncertainties": _jsonable_parameter_dict(self.bestfit_uncertainties),
@@ -1411,6 +1415,8 @@ class ScatteringFitDiagnostics:
                 else [int(value) for value in payload.get("weight_range", [])[:2]]
             ),
             weight_range_basis=payload.get("weight_range_basis"),
+            fit_iterations_requested=_int_or_none(payload.get("fit_iterations_requested")),
+            fit_iterations_completed=_int_or_none(payload.get("fit_iterations_completed")),
             initial_parameters={str(key): value for key, value in payload.get("initial_parameters", {}).items()},
             bestfit_parameters={str(key): value for key, value in payload.get("bestfit_parameters", {}).items()},
             bestfit_uncertainties={str(key): value for key, value in payload.get("bestfit_uncertainties", {}).items()},

--- a/flits/session.py
+++ b/flits/session.py
@@ -2068,25 +2068,38 @@ class BurstSession:
         if fit_result.status == "ok" and "fit" not in updated_flags:
             updated_flags.append("fit")
         updated_uncertainty_details = dict(self.results.uncertainty_details)
-        updated_uncertainty_details.pop("width_ms_model", None)
-        updated_uncertainty_details.pop("tau_sc_ms", None)
-        updated_uncertainty_details.update(
-            {
-                key: value
-                for key, value in fit_result.diagnostics.uncertainty_details.items()
-                if key in {"width_ms_model", "tau_sc_ms"}
-            }
-        )
+        if fit_result.status == "ok":
+            updated_uncertainty_details.pop("width_ms_model", None)
+            updated_uncertainty_details.pop("tau_sc_ms", None)
+            updated_uncertainty_details.update(
+                {
+                    key: value
+                    for key, value in fit_result.diagnostics.uncertainty_details.items()
+                    if key in {"width_ms_model", "tau_sc_ms"}
+                }
+            )
 
         self.results = replace(
             self.results,
-            width_ms_model=fit_result.width_ms_model,
-            tau_sc_ms=fit_result.tau_sc_ms,
+            width_ms_model=(
+                fit_result.width_ms_model
+                if fit_result.status == "ok"
+                else self.results.width_ms_model
+            ),
+            tau_sc_ms=fit_result.tau_sc_ms if fit_result.status == "ok" else self.results.tau_sc_ms,
             measurement_flags=updated_flags,
             uncertainties=replace(
                 self.results.uncertainties,
-                width_ms_model=compatible_scalar_uncertainty(updated_uncertainty_details.get("width_ms_model")),
-                tau_sc_ms=compatible_scalar_uncertainty(updated_uncertainty_details.get("tau_sc_ms")),
+                width_ms_model=(
+                    compatible_scalar_uncertainty(updated_uncertainty_details.get("width_ms_model"))
+                    if fit_result.status == "ok"
+                    else self.results.uncertainties.width_ms_model
+                ),
+                tau_sc_ms=(
+                    compatible_scalar_uncertainty(updated_uncertainty_details.get("tau_sc_ms"))
+                    if fit_result.status == "ok"
+                    else self.results.uncertainties.tau_sc_ms
+                ),
             ),
             uncertainty_details=updated_uncertainty_details,
             diagnostics=replace(
@@ -2094,7 +2107,7 @@ class BurstSession:
                 scattering_fit=fit_result.diagnostics,
             ),
         )
-        if self.temporal_structure is not None:
+        if self.temporal_structure is not None and fit_result.status == "ok":
             updated_widths_ms = self._fitburst_component_widths_ms()
             finite_widths = updated_widths_ms[np.isfinite(updated_widths_ms) & (updated_widths_ms > 0)]
             self.temporal_structure = replace(

--- a/tests/test_fit_scattering.py
+++ b/tests/test_fit_scattering.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
 
+from flits.analysis.fitting import fitburst_adapter
 from flits.analysis.fitting.fitburst_adapter import SpectrumModeler
 from flits.analysis.fitting.fitburst_adapter import FitburstRequestConfig
 from flits.analysis.fitting.fitburst_adapter import FitburstScatteringResult
@@ -119,6 +121,121 @@ def _synthetic_scattering_dispatch_session() -> BurstSession:
     )
 
 
+class _FakeSpectrumModeler:
+    def __init__(
+        self,
+        freqs_mhz: np.ndarray,
+        times_sec: np.ndarray,
+        *,
+        dm_incoherent: float,
+        num_components: int,
+        is_dedispersed: bool,
+    ) -> None:
+        self.freqs_mhz = np.asarray(freqs_mhz, dtype=float)
+        self.times_sec = np.asarray(times_sec, dtype=float)
+        self.parameters: dict[str, list[float] | None] = {}
+        self.update_history: list[dict[str, list[float] | None]] = []
+
+    def update_parameters(self, parameters: dict[str, list[float] | None]) -> None:
+        self.parameters = {
+            key: None if values is None else [float(value) for value in np.asarray(values, dtype=float).ravel()]
+            for key, values in parameters.items()
+        }
+        self.update_history.append(self.parameters)
+
+    def compute_model(self, data: np.ndarray | None = None) -> np.ndarray:
+        if data is not None:
+            return np.zeros_like(data, dtype=float)
+        return np.zeros((self.freqs_mhz.size, self.times_sec.size), dtype=float)
+
+
+class _FakeLSFitter:
+    instances: list["_FakeLSFitter"] = []
+    fit_calls = 0
+    fail_on_call: int | None = None
+
+    def __init__(
+        self,
+        data: np.ndarray,
+        model: _FakeSpectrumModeler,
+        *,
+        good_freq: np.ndarray,
+        weighted_fit: bool,
+        weight_range: list[int] | None,
+    ) -> None:
+        self.data = np.asarray(data, dtype=float)
+        self.model = model
+        self.good_freq = np.asarray(good_freq, dtype=bool)
+        self.weighted_fit = bool(weighted_fit)
+        self.weight_range = weight_range
+        self.model_parameters_at_init = {
+            key: None if values is None else list(values)
+            for key, values in model.parameters.items()
+        }
+        self.fit_parameters: list[str] = []
+        self.fit_statistics: dict[str, object] = {}
+        self.results: SimpleNamespace | None = None
+        type(self).instances.append(self)
+
+    def fix_parameter(self, fixed_parameters: list[str]) -> None:
+        self.fit_parameters = [
+            parameter
+            for parameter in ("amplitude", "arrival_time", "burst_width", "scattering_timescale")
+            if parameter not in fixed_parameters
+        ]
+
+    def fit(self) -> None:
+        type(self).fit_calls += 1
+        call_index = type(self).fit_calls
+        if type(self).fail_on_call == call_index:
+            self.results = SimpleNamespace(success=False, message=f"failed iteration {call_index}")
+            self.fit_statistics = {"chisq_initial": 10.0, "num_fit_parameters": len(self.fit_parameters)}
+            return
+        self.results = SimpleNamespace(success=True, message=f"ok iteration {call_index}")
+        self.fit_statistics = {
+            "chisq_initial": 10.0,
+            "chisq_final": float(10.0 / call_index),
+            "num_fit_parameters": len(self.fit_parameters),
+            "bestfit_parameters": {
+                "amplitude": [float(call_index)],
+                "arrival_time": [0.018],
+                "burst_width": [0.001 + 0.0001 * call_index],
+                "scattering_timescale": [0.002 + 0.0001 * call_index],
+            },
+            "bestfit_uncertainties": {
+                "burst_width": [0.00001],
+                "scattering_timescale": [0.00002],
+            },
+        }
+
+
+def _run_fake_fitburst_fit(*, iterations: int, fitter_class: type[_FakeLSFitter] = _FakeLSFitter) -> FitburstScatteringResult:
+    rng = np.random.default_rng(7)
+    data = rng.normal(0.0, 1.0, size=(6, 48))
+    data[:, 20:26] += 6.0
+
+    _FakeLSFitter.instances = []
+    _FakeLSFitter.fit_calls = 0
+    fitter_class.instances = []
+    fitter_class.fit_calls = 0
+    with (
+        patch.object(fitburst_adapter, "SpectrumModeler", _FakeSpectrumModeler),
+        patch.object(fitburst_adapter, "LSFitter", fitter_class),
+    ):
+        return fitburst_adapter.fit_scattering_selected_band(
+            selected_band=data,
+            freqs_mhz=np.linspace(1450.0, 1250.0, data.shape[0]),
+            time_axis_ms=np.arange(data.shape[1], dtype=float),
+            event_rel_start=18,
+            event_rel_end=30,
+            offpulse_bins=np.r_[0:12, 36:48],
+            tsamp_ms=1.0,
+            peak_rel_bin=23,
+            width_guess_ms=1.5,
+            config=FitburstRequestConfig(iterations=iterations),
+        )
+
+
 @unittest.skipUnless(SpectrumModeler is not None, "fitburst is not installed")
 class FitScatteringTest(unittest.TestCase):
     def test_fit_scattering_recovers_intrinsic_width_and_scattering_time(self) -> None:
@@ -161,6 +278,8 @@ class FitScatteringTest(unittest.TestCase):
         self.assertFalse(results.diagnostics.scattering_fit.weighted_fit)
         self.assertIsNone(results.diagnostics.scattering_fit.weight_range)
         self.assertEqual(results.diagnostics.scattering_fit.weight_range_basis, "unweighted")
+        self.assertEqual(results.diagnostics.scattering_fit.fit_iterations_requested, 1)
+        self.assertEqual(results.diagnostics.scattering_fit.fit_iterations_completed, 1)
 
     def test_weighted_fit_records_offpulse_weighting_diagnostics(self) -> None:
         unweighted_session, _, _ = _synthetic_scattering_session()
@@ -181,21 +300,54 @@ class FitScatteringTest(unittest.TestCase):
 
 
 class FitburstRequestConfigTest(unittest.TestCase):
-    def test_weighted_fit_round_trips_through_request_config(self) -> None:
+    def test_advanced_fit_options_round_trip_through_request_config(self) -> None:
         config = FitburstRequestConfig.from_dict(
             {
                 "num_components": 2,
                 "fixed_parameters": ["dm", "dm_index"],
                 "weighted_fit": True,
                 "weight_range": [3.2, 19.8],
+                "iterations": "3",
             }
         )
 
         self.assertEqual(config.num_components, 2)
         self.assertTrue(config.weighted_fit)
         self.assertEqual(config.weight_range, [3, 20])
+        self.assertEqual(config.iterations, 3)
         self.assertEqual(config.to_dict()["weighted_fit"], True)
         self.assertEqual(config.to_dict()["weight_range"], [3, 20])
+        self.assertEqual(config.to_dict()["iterations"], 3)
+
+    def test_invalid_iteration_count_falls_back_to_one(self) -> None:
+        self.assertEqual(FitburstRequestConfig.from_dict({"iterations": "bad"}).iterations, 1)
+        self.assertEqual(FitburstRequestConfig.from_dict({"iterations": 0}).iterations, 1)
+
+
+class FitburstIterationAdapterTest(unittest.TestCase):
+    def test_iterations_update_model_with_previous_bestfit_parameters(self) -> None:
+        result = _run_fake_fitburst_fit(iterations=2)
+
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(result.diagnostics.fit_iterations_requested, 2)
+        self.assertEqual(result.diagnostics.fit_iterations_completed, 2)
+        self.assertEqual(len(_FakeLSFitter.instances), 2)
+        self.assertEqual(_FakeLSFitter.instances[1].model_parameters_at_init["burst_width"], [0.0011])
+        self.assertAlmostEqual(result.diagnostics.bestfit_parameters["burst_width"][0], 0.0012)
+        self.assertAlmostEqual(result.width_ms_model or 0.0, 1.2)
+
+    def test_failed_intermediate_iteration_returns_completed_bestfit_diagnostics(self) -> None:
+        class FailingSecondFit(_FakeLSFitter):
+            fail_on_call = 2
+
+        result = _run_fake_fitburst_fit(iterations=3, fitter_class=FailingSecondFit)
+
+        self.assertEqual(result.status, "fit_failed")
+        self.assertEqual(result.message, "failed iteration 2")
+        self.assertEqual(result.diagnostics.fit_iterations_requested, 3)
+        self.assertEqual(result.diagnostics.fit_iterations_completed, 1)
+        self.assertEqual(result.diagnostics.bestfit_parameters["burst_width"], [0.0011])
+        self.assertIsNone(result.width_ms_model)
 
 class FitScatteringDispatchTest(unittest.TestCase):
     def test_fitburst_guess_uses_component_regions(self) -> None:
@@ -328,7 +480,7 @@ class FitScatteringDispatchTest(unittest.TestCase):
         self.assertEqual(config.initial_parameters["amplitude"], [0.7, 0.6])
 
     @patch("flits.session.fit_scattering_selected_band")
-    def test_fit_scattering_passes_weighted_fit_config(self, mock_fit: object) -> None:
+    def test_fit_scattering_passes_advanced_fit_config(self, mock_fit: object) -> None:
         session = _synthetic_scattering_dispatch_session()
 
         mock_fit.return_value = FitburstScatteringResult(
@@ -346,11 +498,56 @@ class FitScatteringDispatchTest(unittest.TestCase):
             ),
         )
 
-        session.fit_scattering({"weighted_fit": True, "weight_range": [2, 20]})
+        session.fit_scattering({"weighted_fit": True, "weight_range": [2, 20], "iterations": 3})
 
         config = mock_fit.call_args.kwargs["config"]
         self.assertTrue(config.weighted_fit)
         self.assertEqual(config.weight_range, [2, 20])
+        self.assertEqual(config.iterations, 3)
+
+    @patch("flits.session.fit_scattering_selected_band")
+    def test_failed_refit_preserves_previous_successful_fit_values(self, mock_fit: object) -> None:
+        session = _synthetic_scattering_dispatch_session()
+        mock_fit.side_effect = [
+            FitburstScatteringResult(
+                status="ok",
+                message=None,
+                width_ms_model=1.0,
+                width_uncertainty_ms=None,
+                tau_sc_ms=2.0,
+                tau_uncertainty_ms=None,
+                diagnostics=ScatteringFitDiagnostics(
+                    status="ok",
+                    message=None,
+                    fitter="fitburst",
+                    component_count=1,
+                ),
+            ),
+            FitburstScatteringResult(
+                status="fit_failed",
+                message="failed iteration 2",
+                width_ms_model=None,
+                width_uncertainty_ms=None,
+                tau_sc_ms=None,
+                tau_uncertainty_ms=None,
+                diagnostics=ScatteringFitDiagnostics(
+                    status="fit_failed",
+                    message="failed iteration 2",
+                    fitter="fitburst",
+                    component_count=1,
+                    fit_iterations_requested=3,
+                    fit_iterations_completed=1,
+                ),
+            ),
+        ]
+
+        session.fit_scattering()
+        results = session.fit_scattering({"iterations": 3})
+
+        self.assertEqual(results.width_ms_model, 1.0)
+        self.assertEqual(results.tau_sc_ms, 2.0)
+        self.assertEqual(results.diagnostics.scattering_fit.status, "fit_failed")
+        self.assertEqual(results.diagnostics.scattering_fit.fit_iterations_completed, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an iterations option to FitburstRequestConfig
- rerun fitburst sequentially using the previous best fit as the next initializer
- record requested/completed iteration counts in scattering diagnostics
- preserve previous successful fit scalars when a later refit fails

Closes #42

## Test plan
- /opt/anaconda3/bin/python -m pytest -q tests/test_fit_scattering.py tests/test_web_api.py tests/test_session_snapshots.py tests/test_exports.py
- /opt/anaconda3/bin/python -m pytest -q