### PR TITLE
Drop unsupported fitburst bounds config

### DIFF
--- a/flits/analysis/fitting/fitburst_adapter.py
+++ b/flits/analysis/fitting/fitburst_adapter.py
@@ -96,10 +96,6 @@ class FitburstRequestConfig:
         Number of consecutive fitburst optimizer runs. After each successful
         run, the next run is initialized from the previous best-fit
         parameters.
-    bounds
-        Optional serialized bounds payload. This field is preserved in request
-        dictionaries for API compatibility, but the current adapter does not
-        apply it to ``LSFitter``.
 
     Notes
     -----
@@ -113,7 +109,6 @@ class FitburstRequestConfig:
     weighted_fit: bool = False
     weight_range: list[int] | None = None
     iterations: int = 1
-    bounds: dict[str, list[tuple[float, float]]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible request payload."""
@@ -124,7 +119,6 @@ class FitburstRequestConfig:
             "weighted_fit": bool(self.weighted_fit),
             "weight_range": None if self.weight_range is None else [int(value) for value in self.weight_range],
             "iterations": _coerce_iterations(self.iterations),
-            "bounds": self.bounds,
         }
 
     @classmethod
@@ -143,7 +137,6 @@ class FitburstRequestConfig:
             weighted_fit=_coerce_bool(payload.get("weighted_fit"), default=False),
             weight_range=_coerce_weight_range(payload.get("weight_range")),
             iterations=_coerce_iterations(payload.get("iterations")),
-            bounds=payload.get("bounds"),
         )
 
 

--- a/tests/test_fit_scattering.py
+++ b/tests/test_fit_scattering.py
@@ -323,6 +323,19 @@ class FitburstRequestConfigTest(unittest.TestCase):
         self.assertEqual(FitburstRequestConfig.from_dict({"iterations": "bad"}).iterations, 1)
         self.assertEqual(FitburstRequestConfig.from_dict({"iterations": 0}).iterations, 1)
 
+    def test_legacy_bounds_payload_is_ignored_and_not_serialized(self) -> None:
+        config = FitburstRequestConfig.from_dict(
+            {
+                "bounds": {
+                    "burst_width": [[0.0, 0.01]],
+                    "scattering_timescale": [[0.0, 0.1]],
+                },
+            }
+        )
+
+        self.assertFalse(hasattr(config, "bounds"))
+        self.assertNotIn("bounds", config.to_dict())
+
 
 class FitburstIterationAdapterTest(unittest.TestCase):
     def test_iterations_update_model_with_previous_bestfit_parameters(self) -> None:


### PR DESCRIPTION
## Summary
- remove the unused bounds field from FitburstRequestConfig
- continue tolerating legacy payloads that include bounds
- add regression coverage that bounds are ignored and not serialized

Closes #43

## Test plan
- /opt/anaconda3/bin/python -m pytest -q tests/test_fit_scattering.py tests/test_web_api.py tests/test_session_snapshots.py tests/test_exports.py
- /opt/anaconda3/bin/python -m pytest -q