### PR TITLE
Validate fitburst fixed parameters

### DIFF
--- a/flits/analysis/fitting/fitburst_adapter.py
+++ b/flits/analysis/fitting/fitburst_adapter.py
@@ -35,6 +35,8 @@ MIN_FIT_TIME_BINS = 16
 MIN_WEIGHT_BINS = 8
 FIT_PARAMETERS = ("amplitude", "arrival_time", "burst_width", "scattering_timescale")
 FIXED_PARAMETERS = ("dm", "dm_index", "scattering_index", "spectral_index", "spectral_running")
+FIXABLE_PARAMETERS = FIT_PARAMETERS + FIXED_PARAMETERS
+NON_FITTABLE_PARAMETERS = ("ref_freq",)
 
 
 def _fitburst_uncertainty_detail(
@@ -110,6 +112,10 @@ class FitburstRequestConfig:
     weight_range: list[int] | None = None
     iterations: int = 1
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fixed_parameters", _validate_fixed_parameters(self.fixed_parameters))
+        object.__setattr__(self, "iterations", _coerce_iterations(self.iterations))
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible request payload."""
         return {
@@ -132,7 +138,7 @@ class FitburstRequestConfig:
             num_components = 1
         return cls(
             num_components=max(1, num_components),
-            fixed_parameters=[str(flag) for flag in payload.get("fixed_parameters", ["dm", "dm_index", "scattering_index", "spectral_index", "spectral_running"])],
+            fixed_parameters=payload.get("fixed_parameters", list(FIXED_PARAMETERS)),
             initial_parameters=payload.get("initial_parameters"),
             weighted_fit=_coerce_bool(payload.get("weighted_fit"), default=False),
             weight_range=_coerce_weight_range(payload.get("weight_range")),
@@ -648,6 +654,37 @@ def _coerce_iterations(value: Any) -> int:
     except (TypeError, ValueError):
         return 1
     return max(1, iterations)
+
+
+def _validate_fixed_parameters(values: Any) -> list[str]:
+    if values is None:
+        return list(FIXED_PARAMETERS)
+    if isinstance(values, str):
+        raise ValueError("fixed_parameters must be a list of fitburst parameter names.")
+    try:
+        names = [str(value).strip() for value in values]
+    except TypeError as exc:
+        raise ValueError("fixed_parameters must be a list of fitburst parameter names.") from exc
+
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise ValueError(f"Duplicate fixed fit parameters: {', '.join(duplicates)}.")
+
+    non_fittable = [name for name in names if name in NON_FITTABLE_PARAMETERS]
+    if non_fittable:
+        raise ValueError(
+            f"{', '.join(non_fittable)} is an initialization/reference parameter, not a fittable fitburst parameter."
+        )
+
+    allowed = set(FIXABLE_PARAMETERS)
+    unknown = sorted({name for name in names if name not in allowed})
+    if unknown:
+        raise ValueError(f"Unknown fixed fit parameters: {', '.join(unknown)}.")
+
+    if all(parameter in names for parameter in FIT_PARAMETERS):
+        raise ValueError("At least one fitburst fit parameter must remain free.")
+
+    return names
 
 
 def _coerce_weight_range(values: Any, num_time: int | None = None) -> list[int] | None:

--- a/tests/test_fit_scattering.py
+++ b/tests/test_fit_scattering.py
@@ -336,6 +336,57 @@ class FitburstRequestConfigTest(unittest.TestCase):
         self.assertFalse(hasattr(config, "bounds"))
         self.assertNotIn("bounds", config.to_dict())
 
+    def test_valid_ui_fixed_parameter_payload_is_accepted(self) -> None:
+        config = FitburstRequestConfig.from_dict(
+            {
+                "fixed_parameters": [
+                    "dm",
+                    "dm_index",
+                    "scattering_index",
+                    "spectral_index",
+                    "spectral_running",
+                    "burst_width",
+                ],
+            }
+        )
+
+        self.assertEqual(
+            config.fixed_parameters,
+            [
+                "dm",
+                "dm_index",
+                "scattering_index",
+                "spectral_index",
+                "spectral_running",
+                "burst_width",
+            ],
+        )
+
+    def test_unknown_fixed_parameter_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown fixed fit parameters: made_up"):
+            FitburstRequestConfig.from_dict({"fixed_parameters": ["dm", "made_up"]})
+
+    def test_duplicate_fixed_parameter_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Duplicate fixed fit parameters: dm"):
+            FitburstRequestConfig.from_dict({"fixed_parameters": ["dm", "dm"]})
+
+    def test_ref_freq_fixed_parameter_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ref_freq is an initialization/reference parameter"):
+            FitburstRequestConfig.from_dict({"fixed_parameters": ["ref_freq"]})
+
+    def test_all_fit_parameters_fixed_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "At least one fitburst fit parameter must remain free"):
+            FitburstRequestConfig.from_dict(
+                {
+                    "fixed_parameters": [
+                        "amplitude",
+                        "arrival_time",
+                        "burst_width",
+                        "scattering_timescale",
+                    ],
+                }
+            )
+
 
 class FitburstIterationAdapterTest(unittest.TestCase):
     def test_iterations_update_model_with_previous_bestfit_parameters(self) -> None:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -685,6 +685,25 @@ class WebApiTest(unittest.TestCase):
 
         session.fit_scattering.assert_called_once_with(payload)
 
+    def test_session_action_fit_scattering_rejects_invalid_fixed_parameters(self) -> None:
+        session_id = "synthetic-fit-invalid-fixed-params"
+        session = _synthetic_session()
+        SESSIONS[session_id] = session
+        try:
+            with self.assertRaises(HTTPException) as context:
+                session_action(
+                    session_id,
+                    ActionRequest(
+                        type="fit_scattering",
+                        payload={"fixed_parameters": ["dm", "ref_freq"]},
+                    ),
+                )
+        finally:
+            SESSIONS.pop(session_id, None)
+
+        self.assertEqual(context.exception.status_code, 400)
+        self.assertIn("ref_freq is an initialization/reference parameter", context.exception.detail)
+
     def test_session_action_compute_properties_returns_uncertainty_details(self) -> None:
         session_id = "synthetic-compute-uncertainty"
         session = _synthetic_session()


### PR DESCRIPTION
## Summary
- validate fixed_parameters before calling fitburst
- reject unknown names, duplicates, ref_freq, and all-fit-parameters-fixed payloads
- return clear 400-level web errors for invalid payloads

Closes #44

## Test plan
- /opt/anaconda3/bin/python -m pytest -q tests/test_fit_scattering.py tests/test_web_api.py tests/test_session_snapshots.py tests/test_exports.py
- /opt/anaconda3/bin/python -m pytest -q