### PR TITLE
Capture fitburst failure diagnostics

### DIFF
--- a/flits/analysis/fitting/fitburst_adapter.py
+++ b/flits/analysis/fitting/fitburst_adapter.py
@@ -33,6 +33,7 @@ except Exception:  # pragma: no cover - optional runtime dependency
 MIN_FIT_CHANNELS = 4
 MIN_FIT_TIME_BINS = 16
 MIN_WEIGHT_BINS = 8
+MAX_FITBURST_LOG_CHARS = 4000
 FIT_PARAMETERS = ("amplitude", "arrival_time", "burst_width", "scattering_timescale")
 FIXED_PARAMETERS = ("dm", "dm_index", "scattering_index", "spectral_index", "spectral_running")
 FIXABLE_PARAMETERS = FIT_PARAMETERS + FIXED_PARAMETERS
@@ -366,18 +367,41 @@ def fit_scattering_selected_band(
 
     for _iteration_index in range(fit_iterations):
         model.update_parameters(current_parameters)
-        fitter = LSFitter(
-            fit_data,
-            model,
-            good_freq=good_freq,
-            weighted_fit=weighted_fit and custom_weights is None,
-            weight_range=weight_range if weighted_fit and custom_weights is None else None,
-        )
-        if custom_weights is not None:
-            fitter.weights = custom_weights
-        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-            fitter.fix_parameter(config.fixed_parameters)
-            fitter.fit()
+        stdout_buffer = io.StringIO()
+        stderr_buffer = io.StringIO()
+        fitter = None
+        try:
+            with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+                fitter = LSFitter(
+                    fit_data,
+                    model,
+                    good_freq=good_freq,
+                    weighted_fit=weighted_fit and custom_weights is None,
+                    weight_range=weight_range if weighted_fit and custom_weights is None else None,
+                )
+                if custom_weights is not None:
+                    fitter.weights = custom_weights
+                fitter.fix_parameter(config.fixed_parameters)
+                fitter.fit()
+        except Exception as exc:
+            return _failed_result(
+                status="fit_failed",
+                message="fitburst raised an exception during fitting.",
+                initial_parameters=initial_parameters,
+                bestfit_parameters=current_parameters if completed_iterations > 0 else {},
+                fit_statistics=getattr(fitter, "fit_statistics", {}) if fitter is not None else {},
+                fit_parameters=list(getattr(fitter, "fit_parameters", fit_parameters)) if fitter is not None else fit_parameters,
+                fixed_parameters=config.fixed_parameters,
+                component_count=config.num_components,
+                weighted_fit=weighted_fit,
+                weight_range=weight_range,
+                weight_range_basis=weight_range_basis,
+                fit_iterations_requested=fit_iterations,
+                fit_iterations_completed=completed_iterations,
+                failure_stdout=_sanitize_fitburst_log(stdout_buffer.getvalue()),
+                failure_stderr=_sanitize_fitburst_log(stderr_buffer.getvalue()),
+                failure_exception=_sanitize_fitburst_log(f"{type(exc).__name__}: {exc}"),
+            )
 
         results = getattr(fitter, "results", None)
         if results is None or not getattr(results, "success", False):
@@ -398,6 +422,8 @@ def fit_scattering_selected_band(
                 weight_range_basis=weight_range_basis,
                 fit_iterations_requested=fit_iterations,
                 fit_iterations_completed=completed_iterations,
+                failure_stdout=_sanitize_fitburst_log(stdout_buffer.getvalue()),
+                failure_stderr=_sanitize_fitburst_log(stderr_buffer.getvalue()),
             )
 
         fit_statistics = dict(getattr(fitter, "fit_statistics", {}))
@@ -795,6 +821,29 @@ def _sanitize_fit_statistics(
     return payload
 
 
+def _sanitize_fitburst_log(value: object) -> str | None:
+    """Return a bounded, JSON-safe fitburst diagnostic string."""
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    sanitized = "".join(
+        char
+        if char == "\n" or char == "\t" or ord(char) >= 32
+        else " "
+        for char in text
+    )
+    sanitized = "\n".join(line.rstrip() for line in sanitized.splitlines()).strip()
+    if not sanitized:
+        return None
+    if len(sanitized) <= MAX_FITBURST_LOG_CHARS:
+        return sanitized
+    suffix = "\n[fitburst diagnostic output truncated]"
+    return sanitized[: MAX_FITBURST_LOG_CHARS - len(suffix)] + suffix
+
+
 def _failed_result(
     *,
     status: str,
@@ -810,6 +859,9 @@ def _failed_result(
     weight_range_basis: str | None = None,
     fit_iterations_requested: int | None = None,
     fit_iterations_completed: int | None = None,
+    failure_stdout: str | None = None,
+    failure_stderr: str | None = None,
+    failure_exception: str | None = None,
 ) -> FitburstScatteringResult:
     """Return a structured failure result with empty diagnostic arrays."""
     diagnostics = ScatteringFitDiagnostics(
@@ -824,6 +876,9 @@ def _failed_result(
         weight_range_basis=weight_range_basis,
         fit_iterations_requested=fit_iterations_requested,
         fit_iterations_completed=fit_iterations_completed,
+        failure_stdout=failure_stdout,
+        failure_stderr=failure_stderr,
+        failure_exception=failure_exception,
         initial_parameters=initial_parameters or {},
         bestfit_parameters=bestfit_parameters or {},
         bestfit_uncertainties={},

--- a/flits/models.py
+++ b/flits/models.py
@@ -1339,6 +1339,9 @@ class ScatteringFitDiagnostics:
     weight_range_basis: str | None = None
     fit_iterations_requested: int | None = None
     fit_iterations_completed: int | None = None
+    failure_stdout: str | None = None
+    failure_stderr: str | None = None
+    failure_exception: str | None = None
     initial_parameters: dict[str, list[float] | None] = field(default_factory=dict)
     bestfit_parameters: dict[str, list[float] | None] = field(default_factory=dict)
     bestfit_uncertainties: dict[str, list[float] | None] = field(default_factory=dict)
@@ -1381,6 +1384,9 @@ class ScatteringFitDiagnostics:
             "weight_range_basis": self.weight_range_basis,
             "fit_iterations_requested": _int_or_none(self.fit_iterations_requested),
             "fit_iterations_completed": _int_or_none(self.fit_iterations_completed),
+            "failure_stdout": self.failure_stdout,
+            "failure_stderr": self.failure_stderr,
+            "failure_exception": self.failure_exception,
             "initial_parameters": _jsonable_parameter_dict(self.initial_parameters),
             "bestfit_parameters": _jsonable_parameter_dict(self.bestfit_parameters),
             "bestfit_uncertainties": _jsonable_parameter_dict(self.bestfit_uncertainties),
@@ -1417,6 +1423,9 @@ class ScatteringFitDiagnostics:
             weight_range_basis=payload.get("weight_range_basis"),
             fit_iterations_requested=_int_or_none(payload.get("fit_iterations_requested")),
             fit_iterations_completed=_int_or_none(payload.get("fit_iterations_completed")),
+            failure_stdout=payload.get("failure_stdout"),
+            failure_stderr=payload.get("failure_stderr"),
+            failure_exception=payload.get("failure_exception"),
             initial_parameters={str(key): value for key, value in payload.get("initial_parameters", {}).items()},
             bestfit_parameters={str(key): value for key, value in payload.get("bestfit_parameters", {}).items()},
             bestfit_uncertainties={str(key): value for key, value in payload.get("bestfit_uncertainties", {}).items()},

--- a/tests/test_fit_scattering.py
+++ b/tests/test_fit_scattering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import sys
 from types import SimpleNamespace
 import unittest
 from pathlib import Path
@@ -188,6 +190,8 @@ class _FakeLSFitter:
         type(self).fit_calls += 1
         call_index = type(self).fit_calls
         if type(self).fail_on_call == call_index:
+            print("fitburst stdout before failure " + ("x" * 5000))
+            print("fitburst stderr before failure \x00\x01" + ("y" * 5000), file=sys.stderr)
             self.results = SimpleNamespace(success=False, message=f"failed iteration {call_index}")
             self.fit_statistics = {"chisq_initial": 10.0, "num_fit_parameters": len(self.fit_parameters)}
             return
@@ -411,7 +415,32 @@ class FitburstIterationAdapterTest(unittest.TestCase):
         self.assertEqual(result.diagnostics.fit_iterations_requested, 3)
         self.assertEqual(result.diagnostics.fit_iterations_completed, 1)
         self.assertEqual(result.diagnostics.bestfit_parameters["burst_width"], [0.0011])
+        self.assertLessEqual(len(result.diagnostics.failure_stdout or ""), fitburst_adapter.MAX_FITBURST_LOG_CHARS)
+        self.assertLessEqual(len(result.diagnostics.failure_stderr or ""), fitburst_adapter.MAX_FITBURST_LOG_CHARS)
+        self.assertNotIn("\x00", result.diagnostics.failure_stderr or "")
+        self.assertIn("fitburst diagnostic output truncated", result.diagnostics.failure_stdout or "")
+        json.dumps(result.diagnostics.to_dict())
+        round_tripped = ScatteringFitDiagnostics.from_dict(result.diagnostics.to_dict())
+        self.assertEqual(round_tripped.failure_stdout, result.diagnostics.failure_stdout)
         self.assertIsNone(result.width_ms_model)
+
+    def test_fitburst_exception_records_sanitized_failure_diagnostics(self) -> None:
+        class RaisingFit(_FakeLSFitter):
+            def fit(self) -> None:
+                print("stdout before exception " + ("a" * 5000))
+                print("stderr before exception \x00" + ("b" * 5000), file=sys.stderr)
+                raise RuntimeError("optimizer exploded")
+
+        result = _run_fake_fitburst_fit(iterations=2, fitter_class=RaisingFit)
+
+        self.assertEqual(result.status, "fit_failed")
+        self.assertEqual(result.message, "fitburst raised an exception during fitting.")
+        self.assertIn("RuntimeError: optimizer exploded", result.diagnostics.failure_exception or "")
+        self.assertLessEqual(len(result.diagnostics.failure_stdout or ""), fitburst_adapter.MAX_FITBURST_LOG_CHARS)
+        self.assertLessEqual(len(result.diagnostics.failure_stderr or ""), fitburst_adapter.MAX_FITBURST_LOG_CHARS)
+        self.assertLessEqual(len(result.diagnostics.failure_exception or ""), fitburst_adapter.MAX_FITBURST_LOG_CHARS)
+        self.assertNotIn("\x00", result.diagnostics.failure_stderr or "")
+        json.dumps(result.diagnostics.to_dict())
 
 class FitScatteringDispatchTest(unittest.TestCase):
     def test_fitburst_guess_uses_component_regions(self) -> None:


### PR DESCRIPTION
## Summary
- capture bounded fitburst stdout and stderr on failed fits
- store sanitized failure diagnostics on ScatteringFitDiagnostics
- capture fitburst exceptions with concise user-facing messages
- preserve JSON-safe diagnostics exports

Closes #45

## Test plan
- /opt/anaconda3/bin/python -m pytest -q tests/test_fit_scattering.py tests/test_web_api.py tests/test_session_snapshots.py tests/test_exports.py
- /opt/anaconda3/bin/python -m pytest -q