### PR TITLE
Add fitburst model control config

### DIFF
--- a/flits/analysis/fitting/fitburst_adapter.py
+++ b/flits/analysis/fitting/fitburst_adapter.py
@@ -99,6 +99,13 @@ class FitburstRequestConfig:
         Number of consecutive fitburst optimizer runs. After each successful
         run, the next run is initialized from the previous best-fit
         parameters.
+    factor_time_upsample, factor_freq_upsample
+        Fitburst model upsampling factors. Defaults keep the current FLITS
+        behavior of evaluating on the native selected grid.
+    ref_freq_mhz
+        Optional reference-frequency override in MHz. When omitted, FLITS uses
+        the minimum selected frequency, matching the historical adapter
+        behavior.
 
     Notes
     -----
@@ -112,10 +119,16 @@ class FitburstRequestConfig:
     weighted_fit: bool = False
     weight_range: list[int] | None = None
     iterations: int = 1
+    factor_time_upsample: int = 1
+    factor_freq_upsample: int = 1
+    ref_freq_mhz: float | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "fixed_parameters", _validate_fixed_parameters(self.fixed_parameters))
         object.__setattr__(self, "iterations", _coerce_iterations(self.iterations))
+        object.__setattr__(self, "factor_time_upsample", _coerce_positive_int(self.factor_time_upsample))
+        object.__setattr__(self, "factor_freq_upsample", _coerce_positive_int(self.factor_freq_upsample))
+        object.__setattr__(self, "ref_freq_mhz", _coerce_ref_freq_mhz(self.ref_freq_mhz))
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible request payload."""
@@ -126,6 +139,9 @@ class FitburstRequestConfig:
             "weighted_fit": bool(self.weighted_fit),
             "weight_range": None if self.weight_range is None else [int(value) for value in self.weight_range],
             "iterations": _coerce_iterations(self.iterations),
+            "factor_time_upsample": _coerce_positive_int(self.factor_time_upsample),
+            "factor_freq_upsample": _coerce_positive_int(self.factor_freq_upsample),
+            "ref_freq_mhz": _coerce_ref_freq_mhz(self.ref_freq_mhz),
         }
 
     @classmethod
@@ -144,6 +160,9 @@ class FitburstRequestConfig:
             weighted_fit=_coerce_bool(payload.get("weighted_fit"), default=False),
             weight_range=_coerce_weight_range(payload.get("weight_range")),
             iterations=_coerce_iterations(payload.get("iterations")),
+            factor_time_upsample=_coerce_positive_int(payload.get("factor_time_upsample")),
+            factor_freq_upsample=_coerce_positive_int(payload.get("factor_freq_upsample")),
+            ref_freq_mhz=_coerce_ref_freq_mhz(payload.get("ref_freq_mhz")),
         )
 
 
@@ -331,6 +350,11 @@ def fit_scattering_selected_band(
             overrides=config.initial_parameters,
             num_components=config.num_components,
         )
+    ref_freq_mhz = _coerce_ref_freq_mhz(config.ref_freq_mhz)
+    effective_ref_freq_mhz = float(ref_freq_mhz if ref_freq_mhz is not None else np.min(freqs))
+    initial_parameters["ref_freq"] = [effective_ref_freq_mhz] * config.num_components
+    factor_time_upsample = _coerce_positive_int(config.factor_time_upsample)
+    factor_freq_upsample = _coerce_positive_int(config.factor_freq_upsample)
 
     fit_data = np.array(normalized_data[:, event_rel_start:event_rel_end], dtype=float, copy=True)
     fit_time_axis_ms = time_axis_ms[event_rel_start:event_rel_end]
@@ -354,6 +378,8 @@ def fit_scattering_selected_band(
         freqs,
         times_sec,
         dm_incoherent=0.0,
+        factor_freq_upsample=factor_freq_upsample,
+        factor_time_upsample=factor_time_upsample,
         num_components=config.num_components,
         is_dedispersed=True,
     )
@@ -398,6 +424,9 @@ def fit_scattering_selected_band(
                 weight_range_basis=weight_range_basis,
                 fit_iterations_requested=fit_iterations,
                 fit_iterations_completed=completed_iterations,
+                factor_time_upsample=factor_time_upsample,
+                factor_freq_upsample=factor_freq_upsample,
+                ref_freq_mhz=effective_ref_freq_mhz,
                 failure_stdout=_sanitize_fitburst_log(stdout_buffer.getvalue()),
                 failure_stderr=_sanitize_fitburst_log(stderr_buffer.getvalue()),
                 failure_exception=_sanitize_fitburst_log(f"{type(exc).__name__}: {exc}"),
@@ -422,6 +451,9 @@ def fit_scattering_selected_band(
                 weight_range_basis=weight_range_basis,
                 fit_iterations_requested=fit_iterations,
                 fit_iterations_completed=completed_iterations,
+                factor_time_upsample=factor_time_upsample,
+                factor_freq_upsample=factor_freq_upsample,
+                ref_freq_mhz=effective_ref_freq_mhz,
                 failure_stdout=_sanitize_fitburst_log(stdout_buffer.getvalue()),
                 failure_stderr=_sanitize_fitburst_log(stderr_buffer.getvalue()),
             )
@@ -446,6 +478,9 @@ def fit_scattering_selected_band(
             weight_range_basis=weight_range_basis,
             fit_iterations_requested=fit_iterations,
             fit_iterations_completed=completed_iterations,
+            factor_time_upsample=factor_time_upsample,
+            factor_freq_upsample=factor_freq_upsample,
+            ref_freq_mhz=effective_ref_freq_mhz,
         )
 
     full_best_parameters = current_parameters
@@ -497,6 +532,9 @@ def fit_scattering_selected_band(
         weight_range_basis=weight_range_basis,
         fit_iterations_requested=fit_iterations,
         fit_iterations_completed=completed_iterations,
+        factor_time_upsample=factor_time_upsample,
+        factor_freq_upsample=factor_freq_upsample,
+        ref_freq_mhz=effective_ref_freq_mhz,
         initial_parameters=initial_parameters,
         bestfit_parameters=full_best_parameters,
         bestfit_uncertainties=bestfit_uncertainties,
@@ -682,6 +720,26 @@ def _coerce_iterations(value: Any) -> int:
     return max(1, iterations)
 
 
+def _coerce_positive_int(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 1
+    return max(1, parsed)
+
+
+def _coerce_ref_freq_mhz(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(parsed) or parsed <= 0.0:
+        return None
+    return parsed
+
+
 def _validate_fixed_parameters(values: Any) -> list[str]:
     if values is None:
         return list(FIXED_PARAMETERS)
@@ -859,6 +917,9 @@ def _failed_result(
     weight_range_basis: str | None = None,
     fit_iterations_requested: int | None = None,
     fit_iterations_completed: int | None = None,
+    factor_time_upsample: int | None = None,
+    factor_freq_upsample: int | None = None,
+    ref_freq_mhz: float | None = None,
     failure_stdout: str | None = None,
     failure_stderr: str | None = None,
     failure_exception: str | None = None,
@@ -876,6 +937,9 @@ def _failed_result(
         weight_range_basis=weight_range_basis,
         fit_iterations_requested=fit_iterations_requested,
         fit_iterations_completed=fit_iterations_completed,
+        factor_time_upsample=factor_time_upsample,
+        factor_freq_upsample=factor_freq_upsample,
+        ref_freq_mhz=ref_freq_mhz,
         failure_stdout=failure_stdout,
         failure_stderr=failure_stderr,
         failure_exception=failure_exception,

--- a/flits/models.py
+++ b/flits/models.py
@@ -1342,6 +1342,9 @@ class ScatteringFitDiagnostics:
     failure_stdout: str | None = None
     failure_stderr: str | None = None
     failure_exception: str | None = None
+    factor_time_upsample: int | None = None
+    factor_freq_upsample: int | None = None
+    ref_freq_mhz: float | None = None
     initial_parameters: dict[str, list[float] | None] = field(default_factory=dict)
     bestfit_parameters: dict[str, list[float] | None] = field(default_factory=dict)
     bestfit_uncertainties: dict[str, list[float] | None] = field(default_factory=dict)
@@ -1387,6 +1390,9 @@ class ScatteringFitDiagnostics:
             "failure_stdout": self.failure_stdout,
             "failure_stderr": self.failure_stderr,
             "failure_exception": self.failure_exception,
+            "factor_time_upsample": _int_or_none(self.factor_time_upsample),
+            "factor_freq_upsample": _int_or_none(self.factor_freq_upsample),
+            "ref_freq_mhz": _float_or_none(self.ref_freq_mhz),
             "initial_parameters": _jsonable_parameter_dict(self.initial_parameters),
             "bestfit_parameters": _jsonable_parameter_dict(self.bestfit_parameters),
             "bestfit_uncertainties": _jsonable_parameter_dict(self.bestfit_uncertainties),
@@ -1426,6 +1432,9 @@ class ScatteringFitDiagnostics:
             failure_stdout=payload.get("failure_stdout"),
             failure_stderr=payload.get("failure_stderr"),
             failure_exception=payload.get("failure_exception"),
+            factor_time_upsample=_int_or_none(payload.get("factor_time_upsample")),
+            factor_freq_upsample=_int_or_none(payload.get("factor_freq_upsample")),
+            ref_freq_mhz=_float_or_none(payload.get("ref_freq_mhz")),
             initial_parameters={str(key): value for key, value in payload.get("initial_parameters", {}).items()},
             bestfit_parameters={str(key): value for key, value in payload.get("bestfit_parameters", {}).items()},
             bestfit_uncertainties={str(key): value for key, value in payload.get("bestfit_uncertainties", {}).items()},

--- a/tests/test_fit_scattering.py
+++ b/tests/test_fit_scattering.py
@@ -124,19 +124,26 @@ def _synthetic_scattering_dispatch_session() -> BurstSession:
 
 
 class _FakeSpectrumModeler:
+    instances: list["_FakeSpectrumModeler"] = []
+
     def __init__(
         self,
         freqs_mhz: np.ndarray,
         times_sec: np.ndarray,
         *,
         dm_incoherent: float,
-        num_components: int,
-        is_dedispersed: bool,
+        factor_freq_upsample: int = 1,
+        factor_time_upsample: int = 1,
+        num_components: int = 1,
+        is_dedispersed: bool = False,
     ) -> None:
         self.freqs_mhz = np.asarray(freqs_mhz, dtype=float)
         self.times_sec = np.asarray(times_sec, dtype=float)
+        self.factor_freq_upsample = int(factor_freq_upsample)
+        self.factor_time_upsample = int(factor_time_upsample)
         self.parameters: dict[str, list[float] | None] = {}
         self.update_history: list[dict[str, list[float] | None]] = []
+        type(self).instances.append(self)
 
     def update_parameters(self, parameters: dict[str, list[float] | None]) -> None:
         self.parameters = {
@@ -213,13 +220,19 @@ class _FakeLSFitter:
         }
 
 
-def _run_fake_fitburst_fit(*, iterations: int, fitter_class: type[_FakeLSFitter] = _FakeLSFitter) -> FitburstScatteringResult:
+def _run_fake_fitburst_fit(
+    *,
+    iterations: int,
+    fitter_class: type[_FakeLSFitter] = _FakeLSFitter,
+    config: FitburstRequestConfig | None = None,
+) -> FitburstScatteringResult:
     rng = np.random.default_rng(7)
     data = rng.normal(0.0, 1.0, size=(6, 48))
     data[:, 20:26] += 6.0
 
     _FakeLSFitter.instances = []
     _FakeLSFitter.fit_calls = 0
+    _FakeSpectrumModeler.instances = []
     fitter_class.instances = []
     fitter_class.fit_calls = 0
     with (
@@ -236,7 +249,7 @@ def _run_fake_fitburst_fit(*, iterations: int, fitter_class: type[_FakeLSFitter]
             tsamp_ms=1.0,
             peak_rel_bin=23,
             width_guess_ms=1.5,
-            config=FitburstRequestConfig(iterations=iterations),
+            config=config if config is not None else FitburstRequestConfig(iterations=iterations),
         )
 
 
@@ -284,6 +297,9 @@ class FitScatteringTest(unittest.TestCase):
         self.assertEqual(results.diagnostics.scattering_fit.weight_range_basis, "unweighted")
         self.assertEqual(results.diagnostics.scattering_fit.fit_iterations_requested, 1)
         self.assertEqual(results.diagnostics.scattering_fit.fit_iterations_completed, 1)
+        self.assertEqual(results.diagnostics.scattering_fit.factor_time_upsample, 1)
+        self.assertEqual(results.diagnostics.scattering_fit.factor_freq_upsample, 1)
+        self.assertAlmostEqual(results.diagnostics.scattering_fit.ref_freq_mhz or 0.0, 1250.0)
 
     def test_weighted_fit_records_offpulse_weighting_diagnostics(self) -> None:
         unweighted_session, _, _ = _synthetic_scattering_session()
@@ -312,6 +328,9 @@ class FitburstRequestConfigTest(unittest.TestCase):
                 "weighted_fit": True,
                 "weight_range": [3.2, 19.8],
                 "iterations": "3",
+                "factor_time_upsample": "4",
+                "factor_freq_upsample": 2,
+                "ref_freq_mhz": "1375.5",
             }
         )
 
@@ -319,13 +338,32 @@ class FitburstRequestConfigTest(unittest.TestCase):
         self.assertTrue(config.weighted_fit)
         self.assertEqual(config.weight_range, [3, 20])
         self.assertEqual(config.iterations, 3)
+        self.assertEqual(config.factor_time_upsample, 4)
+        self.assertEqual(config.factor_freq_upsample, 2)
+        self.assertEqual(config.ref_freq_mhz, 1375.5)
         self.assertEqual(config.to_dict()["weighted_fit"], True)
         self.assertEqual(config.to_dict()["weight_range"], [3, 20])
         self.assertEqual(config.to_dict()["iterations"], 3)
+        self.assertEqual(config.to_dict()["factor_time_upsample"], 4)
+        self.assertEqual(config.to_dict()["factor_freq_upsample"], 2)
+        self.assertEqual(config.to_dict()["ref_freq_mhz"], 1375.5)
 
     def test_invalid_iteration_count_falls_back_to_one(self) -> None:
         self.assertEqual(FitburstRequestConfig.from_dict({"iterations": "bad"}).iterations, 1)
         self.assertEqual(FitburstRequestConfig.from_dict({"iterations": 0}).iterations, 1)
+
+    def test_invalid_model_controls_fall_back_to_defaults(self) -> None:
+        config = FitburstRequestConfig.from_dict(
+            {
+                "factor_time_upsample": 0,
+                "factor_freq_upsample": "bad",
+                "ref_freq_mhz": -1.0,
+            }
+        )
+
+        self.assertEqual(config.factor_time_upsample, 1)
+        self.assertEqual(config.factor_freq_upsample, 1)
+        self.assertIsNone(config.ref_freq_mhz)
 
     def test_legacy_bounds_payload_is_ignored_and_not_serialized(self) -> None:
         config = FitburstRequestConfig.from_dict(
@@ -403,6 +441,26 @@ class FitburstIterationAdapterTest(unittest.TestCase):
         self.assertEqual(_FakeLSFitter.instances[1].model_parameters_at_init["burst_width"], [0.0011])
         self.assertAlmostEqual(result.diagnostics.bestfit_parameters["burst_width"][0], 0.0012)
         self.assertAlmostEqual(result.width_ms_model or 0.0, 1.2)
+
+    def test_model_controls_reach_spectrum_modeler_and_diagnostics(self) -> None:
+        result = _run_fake_fitburst_fit(
+            iterations=1,
+            config=FitburstRequestConfig(
+                iterations=1,
+                factor_time_upsample=4,
+                factor_freq_upsample=3,
+                ref_freq_mhz=1400.0,
+            ),
+        )
+
+        self.assertEqual(result.status, "ok")
+        self.assertEqual(len(_FakeSpectrumModeler.instances), 1)
+        self.assertEqual(_FakeSpectrumModeler.instances[0].factor_time_upsample, 4)
+        self.assertEqual(_FakeSpectrumModeler.instances[0].factor_freq_upsample, 3)
+        self.assertEqual(result.diagnostics.factor_time_upsample, 4)
+        self.assertEqual(result.diagnostics.factor_freq_upsample, 3)
+        self.assertEqual(result.diagnostics.ref_freq_mhz, 1400.0)
+        self.assertEqual(result.diagnostics.bestfit_parameters["ref_freq"], [1400.0])
 
     def test_failed_intermediate_iteration_returns_completed_bestfit_diagnostics(self) -> None:
         class FailingSecondFit(_FakeLSFitter):
@@ -591,12 +649,24 @@ class FitScatteringDispatchTest(unittest.TestCase):
             ),
         )
 
-        session.fit_scattering({"weighted_fit": True, "weight_range": [2, 20], "iterations": 3})
+        session.fit_scattering(
+            {
+                "weighted_fit": True,
+                "weight_range": [2, 20],
+                "iterations": 3,
+                "factor_time_upsample": 2,
+                "factor_freq_upsample": 4,
+                "ref_freq_mhz": 1333.0,
+            }
+        )
 
         config = mock_fit.call_args.kwargs["config"]
         self.assertTrue(config.weighted_fit)
         self.assertEqual(config.weight_range, [2, 20])
         self.assertEqual(config.iterations, 3)
+        self.assertEqual(config.factor_time_upsample, 2)
+        self.assertEqual(config.factor_freq_upsample, 4)
+        self.assertEqual(config.ref_freq_mhz, 1333.0)
 
     @patch("flits.session.fit_scattering_selected_band")
     def test_failed_refit_preserves_previous_successful_fit_values(self, mock_fit: object) -> None:


### PR DESCRIPTION
## Summary
- add hidden API/config support for factor_time_upsample, factor_freq_upsample, and ref_freq_mhz
- preserve current defaults: upsampling factors 1 and reference frequency at the selected-band minimum
- record effective model-control values in scattering diagnostics
- test that values reach SpectrumModeler

Closes #47

## Test plan
- /opt/anaconda3/bin/python -m pytest -q tests/test_fit_scattering.py tests/test_web_api.py tests/test_session_snapshots.py tests/test_exports.py
- /opt/anaconda3/bin/python -m pytest -q