### PR TITLE
Partial Feature: Compatible with Folded Pulsar `.fits`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,30 @@ WORKDIR /app
 # when the Python image tag has not been republished yet.
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+        wget \
+        bzip2 \
+        ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Keep the bundled installer current; scanners flag vulnerable pip versions in
 # base images even when the app dependencies themselves are clean.
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade pip
+
+# install mini conda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH=/opt/conda/bin:$PATH
+
+# install psrchive
+RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+    conda install -c conda-forge -y \
+        psrchive && \
+    conda clean -afy
 
 # Install dependencies first so edits to flits/ don't bust this layer.
 # BuildKit cache mount keeps pip's wheel cache across builds without bloating the image.
@@ -37,3 +55,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 EXPOSE 8123
 
 CMD ["flits", "--host", "0.0.0.0", "--port", "8123"]
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,30 +14,12 @@ WORKDIR /app
 # when the Python image tag has not been republished yet.
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
-    apt-get install -y --no-install-recommends \
-        wget \
-        bzip2 \
-        ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Keep the bundled installer current; scanners flag vulnerable pip versions in
 # base images even when the app dependencies themselves are clean.
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade pip
-
-# install mini conda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-latest-Linux-x86_64.sh
-
-ENV PATH=/opt/conda/bin:$PATH
-
-# install psrchive
-RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
-    conda install -c conda-forge -y \
-        psrchive && \
-    conda clean -afy
 
 # Install dependencies first so edits to flits/ don't bust this layer.
 # BuildKit cache mount keeps pip's wheel cache across builds without bloating the image.
@@ -55,6 +37,3 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 EXPOSE 8123
 
 CMD ["flits", "--host", "0.0.0.0", "--port", "8123"]
-
-
-

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fast-Look Interactive Transient Suite.
 FLITS is browser-based FRB analysis software for interactive burst
 inspection, masking, measurement, DM optimization, temporal/spectral
 diagnostics, and export. It reads SIGPROC filterbank (`.fil`),
-search-mode PSRFITS (`.fits`, `.sf`), and CHIME/FRB HDF5 (`.h5`, `.hdf5`)
+PSRFITS search/fold data (`.fits`, `.sf`), and CHIME/FRB HDF5 (`.h5`, `.hdf5`)
 including public catalog waterfalls and beamformed `BBData`
 `tiedbeam_power` files. The I/O layer is pluggable — third parties can
 register custom formats via `importlib` entry points without forking.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ Open `http://127.0.0.1:8123`.
 
 ## 3. Load a burst file
 
-FLITS reads SIGPROC filterbank (`.fil`), search-mode PSRFITS (`.fits`,
+FLITS reads SIGPROC filterbank (`.fil`), PSRFITS search/fold data (`.fits`,
 `.sf`), and CHIME/FRB HDF5 (`.h5`, `.hdf5`) files, including CHIME public
 catalog waterfalls and beamformed `BBData` power files. See
 [Supported Formats](user-guide/supported-formats.md) for the full matrix.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ FLITS, the Fast-Look Interactive Transient Suite, is browser-based software for
 interactive FRB burst analysis. It brings burst inspection, masking,
 measurement, DM optimization, temporal/spectral diagnostics, optional
 model-based fitting, and export into one workflow-oriented tool. Input
-formats include SIGPROC filterbank (`.fil`), search-mode PSRFITS
+formats include SIGPROC filterbank (`.fil`), PSRFITS search/fold data
 (`.fits`, `.sf`), and CHIME/FRB HDF5 (`.h5`, `.hdf5`) including public
 catalog waterfalls and beamformed `BBData` power files, extensible via a
 plugin-based reader framework.

--- a/docs/user-guide/supported-formats.md
+++ b/docs/user-guide/supported-formats.md
@@ -1,13 +1,14 @@
 # Supported Input Formats
 
 FLITS reads filterbank-style data through a pluggable reader framework. The
-three built-in readers cover the formats most common in the FRB community:
+built-in readers cover the formats most common in the FRB community:
 
-| Format           | Extensions       | Backend                              | Notes                                |
-|------------------|------------------|--------------------------------------|--------------------------------------|
-| SIGPROC          | `.fil`           | `your` (filterbank)                  | Canonical input; fully supported.    |
-| PSRFITS (search) | `.fits`, `.sf`   | `your` + `astropy.io.fits` fallback  | Search-mode only; fold-mode rejected.|
-| CHIME/FRB HDF5   | `.h5`, `.hdf5`   | `h5py` (native)                      | `flits_chime_v1`, public catalog, and beamformed `BBData` `tiedbeam_power`. |
+| Format                | Extensions       | Backend                              | Notes                                |
+|-----------------------|------------------|--------------------------------------|--------------------------------------|
+| SIGPROC               | `.fil`           | `your` (filterbank)                  | Canonical input; fully supported.    |
+| PSRFITS (search)      | `.fits`, `.sf`   | `your` + `astropy.io.fits` fallback  | Search-mode dynamic spectra.         |
+| PSRFITS (folded/PSR)  | `.fits`, `.sf`   | `astropy.io.fits`                    | Phase bins are loaded as pseudo-time bins. |
+| CHIME/FRB HDF5        | `.h5`, `.hdf5`   | `h5py` (native)                      | `flits_chime_v1`, public catalog, and beamformed `BBData` `tiedbeam_power`. |
 
 No converter is needed in advance. Just point FLITS at the file: the reader
 framework detects the format by extension, falling back to magic-byte sniffing
@@ -47,8 +48,9 @@ UI surfaces which signal was used via the "Detected: …" label and basis.
 
 ## PSRFITS caveats
 
-- Only **search-mode** PSRFITS is supported. Fold-mode files raise
-  `FormatDetectionError` — FLITS is a burst-analysis tool, not a timing tool.
+- **Folded/PSR-mode** PSRFITS files are supported as a burst-analysis view:
+  FLITS combines subintegrations and treats folded phase bins as pseudo-time
+  bins. It does not perform pulsar timing analysis.
 - Some non-canonical files (MeerKAT, Parkes variants) leave `TSTART`,
   `TELESCOP`, or `SRC_NAME` unset at the layer `your` reads. FLITS
   automatically patches these in from the FITS primary header via

--- a/flits/io/your_reader.py
+++ b/flits/io/your_reader.py
@@ -5,14 +5,12 @@ import os
 import shutil
 import struct
 import tempfile
-import logging
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import ClassVar, Iterator
 
 import numpy as np
-import psrchive
 
 from flits.io.errors import (
     CorruptedDataError,
@@ -22,265 +20,1028 @@ from flits.io.errors import (
 from flits.io.reader import FilterbankInspection
 from flits.io.validation import validate_metadata
 from flits.models import FilterbankMetadata
-from flits.settings import ObservationConfig
+from flits.settings import ObservationConfig, detect_preset, resolve_default_sefd_jy
 from flits.signal import dedisperse, normalize
 
-logger = logging.getLogger(__name__)
-
-# ============================================================
-# Optional dependency: your (SIGPROC backend)
-# ============================================================
 try:
     import your as _your
     _YOUR_IMPORT_ERROR: Exception | None = None
-except Exception as exc:
+except Exception as exc:  # pragma: no cover - depends on optional runtime stack
     _your = SimpleNamespace(Your=None)
     _YOUR_IMPORT_ERROR = exc
 
 your = _your
 
+
 _SIGPROC_MAGIC = struct.pack("i", 12) + b"HEADER_START"
 _FITS_MAGIC = b"SIMPLE  ="
+_PSRFITS_FOLD_MODES = frozenset({"PSR", "FOLD"})
 
-
-# ============================================================
-# Utilities
-# ============================================================
 
 def _is_mmap_deadlock(exc: BaseException) -> bool:
     return isinstance(exc, OSError) and exc.errno == errno.EDEADLK
 
 
+def _close_reader(reader: object | None) -> None:
+    if reader is None:
+        return
+    fp = getattr(reader, "fp", None)
+    if fp is not None and not getattr(fp, "closed", True):
+        try:
+            fp.close()
+        except OSError:
+            pass
+
+
 @contextmanager
 def _open_your(source_path: Path) -> Iterator[object]:
+    """Open a your.Your reader, falling back to a local copy on mmap EDEADLK.
+
+    Some network/FUSE mounts (sshfs, SMB, iCloud) return EDEADLK from mmap();
+    copying to a local tempdir sidesteps this without changing the read path.
+    """
     if your.Your is None:
-        raise RuntimeError("SIGPROC backend 'your' unavailable") from _YOUR_IMPORT_ERROR
+        raise RuntimeError(
+            "The 'your' package is unavailable in the active environment."
+        ) from _YOUR_IMPORT_ERROR
 
-    tmp_path: Path | None = None
-    reader = None
-
+    temp_path: Path | None = None
+    reader: object | None = None
     try:
         try:
             reader = your.Your(str(source_path))
         except OSError as exc:
             if not _is_mmap_deadlock(exc):
                 raise
-
-            tmp_path = Path(tempfile.gettempdir()) / f"flits_{os.getpid()}_{source_path.name}"
-            shutil.copyfile(source_path, tmp_path)
-            reader = your.Your(str(tmp_path))
-
+            tmp_dir = Path(tempfile.gettempdir())
+            temp_path = tmp_dir / f"flits_fb_{os.getpid()}_{source_path.name}"
+            shutil.copyfile(source_path, temp_path)
+            reader = your.Your(str(temp_path))
         yield reader
-
     finally:
-        if reader and hasattr(reader, "fp"):
+        _close_reader(reader)
+        if temp_path is not None:
             try:
-                reader.fp.close()
-            except Exception:
-                pass
-
-        if tmp_path:
-            try:
-                tmp_path.unlink(missing_ok=True)
-            except Exception:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
                 pass
 
 
-# ============================================================
-# PSRFITS HANDLING (STRICT)
-# ============================================================
+def _normalise_polarization_order(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text.upper() if text else None
 
-def _is_psrfits_file(path: Path) -> bool:
-    """Cheap + robust FITS detection."""
+
+def _build_stokes_i(raw: np.ndarray, polarization_order: str | None = None) -> tuple[np.ndarray, int]:
+    normalized_order = _normalise_polarization_order(polarization_order)
+    if raw.ndim == 2:
+        effective_npol = 2 if normalized_order == "IQUV" else 1
+        return raw.T, effective_npol
+    aa = raw[:, 0, :].T
+    if normalized_order == "IQUV" and raw.shape[1] >= 4:
+        return aa, 2
+    if raw.shape[1] >= 2:
+        bb = raw[:, 1, :].T
+        return aa + bb, 2
+    return aa, 1
+
+
+def _decode_source_name(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    text = str(value)
+    return text or None
+
+
+def _safe_int(value: object) -> int | None:
+    if value is None:
+        return None
     try:
-        head = path.read_bytes()[:16]
-        return head.startswith(_FITS_MAGIC)
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if np.isfinite(result) else None
+
+
+def _safe_bool_flag(value: object) -> bool | None:
+    if value is None:
+        return None
+    try:
+        return bool(int(value))
+    except (TypeError, ValueError):
+        text = str(value).strip().lower()
+        if text in {"true", "t", "yes", "y"}:
+            return True
+        if text in {"false", "f", "no", "n"}:
+            return False
+        return None
+
+
+def _first_present(*values: object) -> object | None:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _packed_sexagesimal_to_deg(value: object, *, is_ra: bool) -> float | None:
+    numeric = _safe_float(value)
+    if numeric is None:
+        return None
+    sign = -1.0 if numeric < 0 else 1.0
+    current = abs(numeric)
+    first = int(current // 10000)
+    minutes = int((current - first * 10000) // 100)
+    seconds = current - first * 10000 - minutes * 100
+    if minutes >= 60 or seconds >= 60:
+        return None
+    degrees = first + minutes / 60.0 + seconds / 3600.0
+    if is_ra:
+        return float(degrees * 15.0)
+    return float(sign * degrees)
+
+
+def _coerce_coordinate_deg(value: object, *, is_ra: bool) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            from astropy import units as u
+            from astropy.coordinates import Angle
+
+            unit = u.hourangle if is_ra else u.deg
+            return float(Angle(text, unit=unit).deg)
+        except Exception:
+            return _safe_float(text)
+    numeric = _safe_float(value)
+    if numeric is None:
+        return None
+    if abs(numeric) > 360.0:
+        return _packed_sexagesimal_to_deg(numeric, is_ra=is_ra)
+    return numeric
+
+
+def _reader_timing_metadata(reader: object) -> dict[str, object]:
+    header = getattr(reader, "your_header", None)
+    metadata: dict[str, object] = {}
+    for obj in (reader, header):
+        if obj is None:
+            continue
+        if "source_ra_deg" not in metadata:
+            ra = _coerce_coordinate_deg(
+                _first_present(
+                    getattr(obj, "ra_deg", None),
+                    getattr(obj, "src_raj", None),
+                    getattr(obj, "RAJ", None),
+                ),
+                is_ra=True,
+            )
+            if ra is not None:
+                metadata["source_ra_deg"] = ra
+        if "source_dec_deg" not in metadata:
+            dec = _coerce_coordinate_deg(
+                _first_present(
+                    getattr(obj, "dec_deg", None),
+                    getattr(obj, "src_dej", None),
+                    getattr(obj, "DECJ", None),
+                ),
+                is_ra=False,
+            )
+            if dec is not None:
+                metadata["source_dec_deg"] = dec
+        if "barycentric_header_flag" not in metadata:
+            bary = _safe_bool_flag(getattr(obj, "barycentric", None))
+            if bary is not None:
+                metadata["barycentric_header_flag"] = bary
+        if "pulsarcentric_header_flag" not in metadata:
+            pulsar = _safe_bool_flag(getattr(obj, "pulsarcentric", None))
+            if pulsar is not None:
+                metadata["pulsarcentric_header_flag"] = pulsar
+    if "source_ra_deg" in metadata and "source_dec_deg" in metadata:
+        metadata["source_position_basis"] = "reader_header"
+    return metadata
+
+
+def _peek_bytes(path: Path, n: int) -> bytes:
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(n)
+    except OSError:
+        return b""
+
+
+def _is_psrfits_search_mode(path: Path) -> tuple[bool, str | None]:
+    """Inspect a FITS primary header to detect fold-mode PSRFITS.
+
+    Returns (is_search_mode, obs_mode_value). If astropy isn't available, returns
+    (True, None) optimistically — `your` will fail informatively on fold files.
+    """
+    try:
+        from astropy.io import fits
+    except Exception:
+        return True, None
+
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            primary = hdul[0].header
+            obs_mode = str(primary.get("OBS_MODE", "")).strip().upper()
+    except Exception:
+        return True, None
+
+    if not obs_mode:
+        return True, None
+    return obs_mode.startswith("SEARCH"), obs_mode
+
+
+def _is_psrfits_fold_mode(path: Path) -> tuple[bool, str | None]:
+    try:
+        from astropy.io import fits
+    except Exception:
+        return False, None
+
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            obs_mode = str(hdul[0].header.get("OBS_MODE", "")).strip().upper()
+    except Exception:
+        return False, None
+
+    return obs_mode in _PSRFITS_FOLD_MODES, obs_mode or None
+
+
+def _find_psrfits_subint(hdul: object) -> object | None:
+    return next(
+        (
+            hdu
+            for hdu in hdul[1:]
+            if str(hdu.header.get("EXTNAME", "")).strip().upper() == "SUBINT"
+        ),
+        None,
+    )
+
+
+def _looks_like_psrfits(path: Path) -> bool:
+    """Return True only for FITS files that look structurally like PSRFITS."""
+    try:
+        from astropy.io import fits
+    except Exception:
+        return False
+
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            primary = hdul[0].header
+            fitstype = str(primary.get("FITSTYPE", "")).strip().upper()
+            obs_mode = str(primary.get("OBS_MODE", "")).strip().upper()
+            subint = _find_psrfits_subint(hdul)
+            if subint is None:
+                return False
+
+            subint_header = subint.header
+            subint_keywords_present = all(
+                key in subint_header for key in ("TBIN", "NCHAN", "NPOL")
+            )
+            primary_looks_psrfits = (
+                "PSRFITS" in fitstype or "STT_IMJD" in primary or "STT_SMJD" in primary
+            )
+            mode_supported = (
+                (not obs_mode)
+                or obs_mode.startswith("SEARCH")
+                or obs_mode in _PSRFITS_FOLD_MODES
+            )
+            return mode_supported and (primary_looks_psrfits or subint_keywords_present)
     except Exception:
         return False
 
 
-def _psrchive_is_fold_mode(path: Path) -> bool:
-    """Single authoritative check using PSRCHIVE."""
+def _psrfits_primary_fallback(path: Path) -> dict[str, object]:
+    """Extract commonly-missing PSRFITS metadata directly from the FITS headers.
+
+    `your`'s PSRFITS handling occasionally leaves `tstart`, `telescope_id`, or
+    `source_name` unset on non-canonical files (some MeerKAT/Parkes variants).
+    This pulls them from the primary and SUBINT headers via astropy.
+    """
     try:
-        ar = psrchive.Archive_load(str(path))
-        ar_type = str(ar.get_type()).lower() if ar.get_type() else ""
-        return "fold" in ar_type
+        from astropy.io import fits
     except Exception:
-        return False
+        return {}
+
+    out: dict[str, object] = {}
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            primary = hdul[0].header
+            stt_imjd = primary.get("STT_IMJD")
+            stt_smjd = primary.get("STT_SMJD")
+            stt_offs = primary.get("STT_OFFS", 0.0) or 0.0
+            if stt_imjd is not None and stt_smjd is not None:
+                out["tstart"] = float(stt_imjd) + (float(stt_smjd) + float(stt_offs)) / 86400.0
+            telescope = primary.get("TELESCOP")
+            if telescope:
+                out["telescope_name"] = str(telescope).strip()
+            source = primary.get("SRC_NAME")
+            if source:
+                out["source_name"] = str(source).strip()
+            ra = None
+            for candidate in (primary.get("RAJ"), primary.get("RA"), primary.get("OBJCTRA")):
+                ra = _coerce_coordinate_deg(candidate, is_ra=True)
+                if ra is not None:
+                    break
+            dec = None
+            for candidate in (primary.get("DECJ"), primary.get("DEC"), primary.get("OBJCTDEC")):
+                dec = _coerce_coordinate_deg(candidate, is_ra=False)
+                if dec is not None:
+                    break
+            if ra is not None and dec is not None:
+                out["source_ra_deg"] = float(ra)
+                out["source_dec_deg"] = float(dec)
+                out["source_position_basis"] = "psrfits_primary_header"
+            bary = _safe_bool_flag(_first_present(primary.get("BARYCENT"), primary.get("BARYCORR")))
+            if bary is not None:
+                out["barycentric_header_flag"] = bary
+            pulsar = _safe_bool_flag(_first_present(primary.get("PULSAREN"), primary.get("PULSARC")))
+            if pulsar is not None:
+                out["pulsarcentric_header_flag"] = pulsar
+    except Exception:
+        return out
+    return out
 
 
-def _load_folded_psrchive(
+def _decode_telescope_name(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace").strip()
+    else:
+        text = str(value).strip()
+    return text or None
+
+
+def _peek_header_freq_range(header: object) -> tuple[float | None, float | None]:
+    """Return (lo, hi) MHz from a `your` header, or (None, None) if any field is missing."""
+    fch1 = getattr(header, "fch1", None)
+    foff = getattr(header, "foff", None)
+    nchans = getattr(header, "nchans", None)
+    try:
+        if fch1 is None or foff is None or nchans is None:
+            return (None, None)
+        fch1_f = float(fch1)
+        foff_f = float(foff)
+        nchans_i = int(nchans)
+    except (TypeError, ValueError):
+        return (None, None)
+    if nchans_i <= 0 or not np.isfinite(fch1_f) or not np.isfinite(foff_f):
+        return (None, None)
+    lo = fch1_f
+    hi = fch1_f + foff_f * (nchans_i - 1)
+    return (min(lo, hi), max(lo, hi))
+
+
+def _folded_psrfits_dimensions(subint: object, path: Path) -> tuple[int, int, int]:
+    header = subint.header
+    missing: list[str] = []
+    nbin = _safe_int(header.get("NBIN"))
+    nchan = _safe_int(header.get("NCHAN"))
+    npol = _safe_int(header.get("NPOL"))
+    if nbin is None or nbin <= 0:
+        missing.append("SUBINT.NBIN")
+    if nchan is None or nchan <= 0:
+        missing.append("SUBINT.NCHAN")
+    if npol is None or npol <= 0:
+        missing.append("SUBINT.NPOL")
+    if missing:
+        raise MetadataMissingError(
+            f"Folded PSRFITS SUBINT header missing required dimensions: {', '.join(missing)}",
+            path=path,
+            fields=tuple(missing),
+        )
+    return int(nbin), int(nchan), int(npol)
+
+
+def _psrparam_float(hdul: object, *names: str) -> float | None:
+    wanted = {name.upper() for name in names}
+    try:
+        table = hdul["PSRPARAM"].data
+    except Exception:
+        return None
+    for row in table:
+        try:
+            text = row["PARAM"]
+        except Exception:
+            continue
+        if isinstance(text, bytes):
+            text = text.decode("utf-8", errors="replace")
+        parts = str(text).strip().split()
+        if len(parts) < 2 or parts[0].upper() not in wanted:
+            continue
+        value = _safe_float(parts[1])
+        if value is not None:
+            return value
+    return None
+
+
+def _folded_psrfits_period_sec(hdul: object, subint: object, path: Path) -> float:
+    column_names = set(getattr(subint, "columns", ()).names or ())
+    if "PERIOD" in column_names:
+        for row in subint.data:
+            period = _safe_float(row["PERIOD"])
+            if period is not None and period > 0.0:
+                return period
+
+    p0 = _psrparam_float(hdul, "P0")
+    if p0 is not None and p0 > 0.0:
+        return p0
+
+    f0 = _psrparam_float(hdul, "F0")
+    if f0 is not None and f0 > 0.0:
+        return 1.0 / f0
+
+    nbin, _, _ = _folded_psrfits_dimensions(subint, path)
+    tbin = _safe_float(subint.header.get("TBIN"))
+    if tbin is not None and tbin > 0.0:
+        return tbin * nbin
+
+    raise MetadataMissingError(
+        "Folded PSRFITS requires a positive PERIOD, P0, F0, or TBIN to define pseudo-time bins",
+        path=path,
+        fields=("SUBINT.PERIOD", "PSRPARAM.P0", "PSRPARAM.F0", "SUBINT.TBIN"),
+    )
+
+
+def _folded_psrfits_freqs_mhz(hdul: object, subint: object, path: Path) -> np.ndarray:
+    _, nchan, _ = _folded_psrfits_dimensions(subint, path)
+    column_names = set(getattr(subint, "columns", ()).names or ())
+    if "DAT_FREQ" in column_names and len(subint.data) > 0:
+        freqs = np.asarray(subint.data[0]["DAT_FREQ"], dtype=float).reshape(-1)
+        if freqs.size == nchan and np.all(np.isfinite(freqs)):
+            return freqs
+
+    primary = hdul[0].header
+    obsfreq = _safe_float(primary.get("OBSFREQ"))
+    chan_bw = _safe_float(subint.header.get("CHAN_BW"))
+    if chan_bw is None:
+        obsbw = _safe_float(primary.get("OBSBW"))
+        chan_bw = None if obsbw is None else obsbw / nchan
+    if obsfreq is None or chan_bw is None or chan_bw == 0.0:
+        raise MetadataMissingError(
+            "Folded PSRFITS requires DAT_FREQ or OBSFREQ plus CHAN_BW/OBSBW",
+            path=path,
+            fields=("SUBINT.DAT_FREQ", "OBSFREQ", "SUBINT.CHAN_BW"),
+        )
+    first = obsfreq - chan_bw * ((nchan - 1) / 2.0)
+    return first + chan_bw * np.arange(nchan, dtype=float)
+
+
+def _folded_psrfits_scale(
+    value: object,
+    *,
+    npol: int,
+    nchan: int,
+    default: float,
+    path: Path,
+    field_name: str,
+) -> np.ndarray:
+    if value is None:
+        return np.full((npol, nchan), default, dtype=np.float32)
+    arr = np.asarray(value, dtype=np.float32).reshape(-1)
+    if arr.size == 0:
+        return np.full((npol, nchan), default, dtype=np.float32)
+    if arr.size == 1:
+        return np.full((npol, nchan), float(arr[0]), dtype=np.float32)
+    if arr.size == nchan:
+        return np.broadcast_to(arr.reshape(1, nchan), (npol, nchan)).astype(np.float32, copy=False)
+    if arr.size == npol * nchan:
+        return arr.reshape(npol, nchan)
+    raise CorruptedDataError(
+        f"Folded PSRFITS {field_name} has {arr.size} values; expected 1, {nchan}, or {npol * nchan}",
+        path=path,
+    )
+
+
+def _folded_psrfits_raw_data(row: object, *, nbin: int, nchan: int, npol: int, path: Path) -> np.ndarray:
+    try:
+        raw = np.asarray(row["DATA"], dtype=np.float32)
+    except Exception as exc:
+        raise MetadataMissingError(
+            "Folded PSRFITS SUBINT row is missing DATA",
+            path=path,
+            fields=("SUBINT.DATA",),
+        ) from exc
+
+    expected = npol * nchan * nbin
+    if raw.size != expected:
+        raise CorruptedDataError(
+            f"Folded PSRFITS DATA has {raw.size} values; expected {expected}",
+            path=path,
+        )
+    if raw.shape == (npol, nchan, nbin):
+        return raw
+    if npol == 1 and raw.shape == (nchan, nbin):
+        return raw.reshape(1, nchan, nbin)
+    return raw.reshape(npol, nchan, nbin)
+
+
+def _build_folded_stokes_i(raw: np.ndarray, polarization_order: str | None) -> tuple[np.ndarray, int]:
+    normalized_order = _normalise_polarization_order(polarization_order)
+    if raw.shape[0] == 1:
+        return raw[0, :, :], 1
+    if normalized_order == "IQUV":
+        return raw[0, :, :], 2
+    return raw[0, :, :] + raw[1, :, :], 2
+
+
+def _folded_psrfits_waterfall(subint: object, path: Path) -> tuple[np.ndarray, int]:
+    nbin, nchan, npol = _folded_psrfits_dimensions(subint, path)
+    polarization_order = _normalise_polarization_order(str(subint.header.get("POL_TYPE", "")).strip())
+    column_names = set(getattr(subint, "columns", ()).names or ())
+    rows: list[np.ndarray] = []
+    effective_npol = 1
+    for row in subint.data:
+        raw = _folded_psrfits_raw_data(row, nbin=nbin, nchan=nchan, npol=npol, path=path)
+        scl = _folded_psrfits_scale(
+            row["DAT_SCL"] if "DAT_SCL" in column_names else None,
+            npol=npol,
+            nchan=nchan,
+            default=1.0,
+            path=path,
+            field_name="DAT_SCL",
+        )
+        offs = _folded_psrfits_scale(
+            row["DAT_OFFS"] if "DAT_OFFS" in column_names else None,
+            npol=npol,
+            nchan=nchan,
+            default=0.0,
+            path=path,
+            field_name="DAT_OFFS",
+        )
+        scaled = raw * scl[:, :, np.newaxis] + offs[:, :, np.newaxis]
+        stokes_i, effective_npol = _build_folded_stokes_i(scaled, polarization_order)
+        rows.append(stokes_i)
+
+    if not rows:
+        raise CorruptedDataError("Folded PSRFITS SUBINT table contains no rows", path=path)
+    if len(rows) == 1:
+        return rows[0].astype(np.float32, copy=False), effective_npol
+    return np.mean(np.stack(rows, axis=0), axis=0).astype(np.float32, copy=False), effective_npol
+
+
+def _inspect_folded_psrfits(path: Path) -> FilterbankInspection:
+    try:
+        from astropy.io import fits
+    except Exception as exc:
+        raise RuntimeError("The 'astropy' package is required for folded PSRFITS files.") from exc
+
+    with fits.open(path, memmap=False) as hdul:
+        subint = _find_psrfits_subint(hdul)
+        if subint is None:
+            raise FormatDetectionError("Folded PSRFITS file is missing a SUBINT table.", path=path)
+        freqs_mhz = _folded_psrfits_freqs_mhz(hdul, subint, path)
+        primary = hdul[0].header
+        source_name = _decode_source_name(primary.get("SRC_NAME"))
+        telescope_name = _decode_telescope_name(primary.get("TELESCOP"))
+
+    timing_metadata = _psrfits_primary_fallback(path)
+    detected_preset_key, detection_basis = detect_preset(
+        None,
+        None,
+        telescope_name=telescope_name,
+        schema_version="psrfits_fold",
+        freq_lo_mhz=float(np.min(freqs_mhz)),
+        freq_hi_mhz=float(np.max(freqs_mhz)),
+    )
+    return FilterbankInspection(
+        source_path=path,
+        source_name=source_name,
+        telescope_id=None,
+        machine_id=None,
+        detected_preset_key=detected_preset_key,
+        detection_basis=detection_basis,
+        telescope_name=telescope_name,
+        schema_version="psrfits_fold",
+        freq_lo_mhz=float(np.min(freqs_mhz)),
+        freq_hi_mhz=float(np.max(freqs_mhz)),
+        source_ra_deg=_safe_float(timing_metadata.get("source_ra_deg")),
+        source_dec_deg=_safe_float(timing_metadata.get("source_dec_deg")),
+        source_position_basis=timing_metadata.get("source_position_basis"),  # type: ignore[arg-type]
+        time_scale="utc",
+        time_reference_frame="topocentric",
+        barycentric_header_flag=_safe_bool_flag(timing_metadata.get("barycentric_header_flag")),
+        pulsarcentric_header_flag=_safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag")),
+    )
+
+
+def _load_folded_psrfits(
     path: Path,
     config: ObservationConfig,
+    inspection: FilterbankInspection | None = None,
 ) -> tuple[np.ndarray, FilterbankMetadata]:
+    try:
+        from astropy.io import fits
+    except Exception as exc:
+        raise RuntimeError("The 'astropy' package is required for folded PSRFITS files.") from exc
 
-    logger.info(f"[PSRCHIVE] folded load: {path.name}")
+    with fits.open(path, memmap=False) as hdul:
+        subint = _find_psrfits_subint(hdul)
+        if subint is None:
+            raise FormatDetectionError("Folded PSRFITS file is missing a SUBINT table.", path=path)
+        nbin, _, header_npol = _folded_psrfits_dimensions(subint, path)
+        period_sec = _folded_psrfits_period_sec(hdul, subint, path)
+        tsamp = period_sec / nbin
+        freqs_mhz = _folded_psrfits_freqs_mhz(hdul, subint, path)
+        polarization_order = _normalise_polarization_order(str(subint.header.get("POL_TYPE", "")).strip())
+        chan_bw = _safe_float(subint.header.get("CHAN_BW"))
+        stokes_i, effective_npol = _folded_psrfits_waterfall(subint, path)
 
-    ar = psrchive.Archive_load(str(path))
-    ar.remove_baseline()
+    filterbank_inspection = inspection or _inspect_folded_psrfits(path)
+    timing_metadata = _psrfits_primary_fallback(path)
+    start_mjd = _safe_float(timing_metadata.get("tstart"))
+    if start_mjd is None:
+        raise MetadataMissingError(
+            "Folded PSRFITS requires STT_IMJD and STT_SMJD to define start_mjd",
+            path=path,
+            fields=("STT_IMJD", "STT_SMJD"),
+        )
 
-    if not ar.get_dedispersed():
-        ar.dedisperse()
+    read_start_sec = config.read_start_for_file(path.name)
+    nstart = min(max(int(read_start_sec / tsamp), 0), max(stokes_i.shape[1] - 1, 0))
+    nread = stokes_i.shape[1] - nstart
+    if config.read_end_sec is not None:
+        nend = max(nstart + 1, int(config.read_end_sec / tsamp))
+        nread = min(nread, nend - nstart)
+    stokes_i = stokes_i[:, nstart : nstart + nread]
 
-    dm = float(ar.get_dispersion_measure())
-    period = float(ar[0].get_folding_period())
+    effective_npol = (
+        max(1, int(config.npol_override)) if config.npol_override is not None else effective_npol
+    )
+    if abs(float(config.dm)) > 0.0:
+        stokes_i = dedisperse(stokes_i, config.dm, freqs_mhz, tsamp)
 
-    data = ar.get_data()  # (subint, pol, chan, bin)
+    tail_fraction = float(np.clip(config.normalization_tail_fraction, 0.05, 0.95))
+    offpulse_start = min(stokes_i.shape[1] - 1, int((1 - tail_fraction) * stokes_i.shape[1]))
+    offpulse = stokes_i[:, offpulse_start:]
+    stokes_i = normalize(stokes_i, offpulse).astype(np.float32, copy=False)
 
-    # → Stokes I
-    data = data[:, 0, :, :]        # (subint, chan, bin)
-    dyn = np.mean(data, axis=2)    # (subint, chan)
-    dyn = dyn.T                    # (chan, subint)
-
-    freqs = np.asarray(ar.get_frequencies(), dtype=float)
-    order = np.argsort(freqs)
-
-    freqs = freqs[order]
-    dyn = dyn[order, :]
-
-    dyn = normalize(dyn, dyn[:, int(0.8 * dyn.shape[1]):]).astype(np.float32)
+    diffs = np.diff(freqs_mhz.astype(float))
+    freqres = (
+        float(abs(chan_bw))
+        if chan_bw is not None and np.isfinite(chan_bw) and chan_bw != 0.0
+        else (float(abs(np.median(diffs))) if diffs.size else 0.0)
+    )
+    bandwidth_mhz = freqres * int(freqs_mhz.size)
+    sefd_jy = config.sefd_jy
+    if sefd_jy is None:
+        sefd_jy = resolve_default_sefd_jy(
+            config.preset_key,
+            float(np.min(freqs_mhz)),
+            float(np.max(freqs_mhz)),
+        )
 
     metadata = FilterbankMetadata(
         source_path=path,
-        source_name=path.stem,
-
-        tsamp=period,
-        freqres=float(abs(freqs[1] - freqs[0])) if len(freqs) > 1 else 0.0,
-        start_mjd=float(ar.get_start_time().in_days()) if ar.get_start_time() else 0.0,
-
-        sefd_jy=config.sefd_jy or 1.0,
-        bandwidth_mhz=float(freqs.max() - freqs.min()),
-
-        npol=1,
-        freqs_mhz=freqs,
-        header_npol=1,
-
-        telescope_name=str(ar.get_telescope()) if ar.get_telescope() else "unknown",
-
-        detected_preset_key="psrchive_fold",
-        detection_basis="folded_psrfits",
-
-        time_scale="folded",
-        time_reference_frame="topocentric",
+        source_name=filterbank_inspection.source_name,
+        tsamp=tsamp,
+        freqres=freqres,
+        start_mjd=start_mjd,
+        read_start_sec=read_start_sec,
+        sefd_jy=sefd_jy,
+        bandwidth_mhz=bandwidth_mhz,
+        npol=effective_npol,
+        freqs_mhz=freqs_mhz,
+        header_npol=header_npol,
+        polarization_order=polarization_order,
+        telescope_id=filterbank_inspection.telescope_id,
+        machine_id=filterbank_inspection.machine_id,
+        detected_preset_key=filterbank_inspection.detected_preset_key,
+        detection_basis=filterbank_inspection.detection_basis,
+        source_ra_deg=filterbank_inspection.source_ra_deg,
+        source_dec_deg=filterbank_inspection.source_dec_deg,
+        source_position_basis=filterbank_inspection.source_position_basis,
+        time_scale=filterbank_inspection.time_scale or "utc",
+        time_reference_frame=filterbank_inspection.time_reference_frame or "topocentric",
+        barycentric_header_flag=filterbank_inspection.barycentric_header_flag,
+        pulsarcentric_header_flag=filterbank_inspection.pulsarcentric_header_flag,
+        dedispersion_reference_frequency_mhz=(
+            float(np.max(freqs_mhz)) if abs(float(config.dm)) > 0.0 else None
+        ),
+        dedispersion_reference_basis=(
+            "flits_integer_bin_dedispersion_max_frequency" if abs(float(config.dm)) > 0.0 else None
+        ),
     )
+    return stokes_i, validate_metadata(metadata)
 
-    return dyn, validate_metadata(metadata)
 
+def _coerce_header_field(
+    header: object,
+    name: str,
+    *,
+    fallback: object | None = None,
+    required: bool = True,
+    path: Path | None = None,
+) -> object:
+    value = getattr(header, name, None)
+    if value is None or (isinstance(value, float) and not np.isfinite(value)):
+        if fallback is not None:
+            return fallback
+        if required:
+            raise MetadataMissingError(
+                f"Header field {name!r} missing and no fallback available",
+                path=path,
+                fields=(name,),
+            )
+    return value
 
-# ============================================================
-# MAIN READER
-# ============================================================
 
 class YourFilterbankReader:
-    """
-    Clean, strict, non-ambiguous reader:
+    """Reader backed by `your` for SIGPROC/search PSRFITS and Astropy for folded PSRFITS.
 
-    SIGPROC (.fil) → your backend
-    PSRFITS fold   → psrchive ONLY
-    PSRFITS search → REJECTED (explicit)
+    Folded PSRFITS files are exposed as pseudo-time waterfalls by treating phase
+    bins as time bins and averaging subintegrations.
     """
 
     format_id: ClassVar[str] = "sigproc"
+    format_id_aliases: ClassVar[tuple[str, ...]] = ("psrfits", "your", "fil", "fits")
     extensions: ClassVar[tuple[str, ...]] = (".fil", ".fits", ".sf")
 
-    # --------------------------------------------------------
     def sniff(self, path: Path) -> bool:
-        try:
-            head = path.read_bytes()[:16]
-        except Exception:
-            return False
-
+        head = _peek_bytes(path, 16)
         if head.startswith(_SIGPROC_MAGIC):
             return True
-
         if head.startswith(_FITS_MAGIC):
-            return _is_psrfits_file(path)
-
+            return _looks_like_psrfits(path)
         return False
 
-    # --------------------------------------------------------
+    def inspect(self, path: Path) -> FilterbankInspection:
+        source_path = Path(path).expanduser().resolve()
+        is_fits = source_path.suffix.lower() in {".fits", ".sf"}
+
+        if is_fits:
+            is_search, obs_mode = _is_psrfits_search_mode(source_path)
+            is_fold, _ = _is_psrfits_fold_mode(source_path)
+            if is_fold:
+                return _inspect_folded_psrfits(source_path)
+            if not is_search:
+                raise FormatDetectionError(
+                    f"PSRFITS file is in {obs_mode!r} mode; FLITS supports SEARCH and PSR fold-mode data.",
+                    path=source_path,
+                )
+
+        fits_fallback = _psrfits_primary_fallback(source_path) if is_fits else {}
+
+        with _open_your(source_path) as reader:
+            telescope_id = _safe_int(getattr(reader, "telescope_id", None))
+            machine_id = _safe_int(getattr(reader, "machine_id", None))
+            source_name = _decode_source_name(getattr(reader, "source_name", None))
+            telescope_name = _decode_telescope_name(
+                getattr(reader, "telescope_name", None)
+                or getattr(getattr(reader, "your_header", None), "telescope", None)
+            )
+            freq_lo, freq_hi = _peek_header_freq_range(getattr(reader, "your_header", None))
+            timing_metadata = _reader_timing_metadata(reader)
+
+        if is_fits and source_name is None:
+            source_name = fits_fallback.get("source_name")  # type: ignore[assignment]
+        if telescope_name is None:
+            telescope_name = fits_fallback.get("telescope_name")  # type: ignore[assignment]
+        for key in (
+            "source_ra_deg",
+            "source_dec_deg",
+            "source_position_basis",
+            "barycentric_header_flag",
+            "pulsarcentric_header_flag",
+        ):
+            if key not in timing_metadata and key in fits_fallback:
+                timing_metadata[key] = fits_fallback[key]
+
+        schema_version = "psrfits_search" if is_fits else "sigproc_search"
+
+        detected_preset_key, detection_basis = detect_preset(
+            telescope_id,
+            machine_id,
+            telescope_name=telescope_name,
+            schema_version=schema_version,
+            freq_lo_mhz=freq_lo,
+            freq_hi_mhz=freq_hi,
+        )
+        return FilterbankInspection(
+            source_path=source_path,
+            source_name=source_name,
+            telescope_id=telescope_id,
+            machine_id=machine_id,
+            detected_preset_key=detected_preset_key,
+            detection_basis=detection_basis,
+            telescope_name=telescope_name,
+            schema_version=schema_version,
+            freq_lo_mhz=freq_lo,
+            freq_hi_mhz=freq_hi,
+            source_ra_deg=_safe_float(timing_metadata.get("source_ra_deg")),
+            source_dec_deg=_safe_float(timing_metadata.get("source_dec_deg")),
+            source_position_basis=timing_metadata.get("source_position_basis"),  # type: ignore[arg-type]
+            time_scale="utc",
+            time_reference_frame="topocentric",
+            barycentric_header_flag=_safe_bool_flag(timing_metadata.get("barycentric_header_flag")),
+            pulsarcentric_header_flag=_safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag")),
+        )
+
     def load(
         self,
         path: Path,
         config: ObservationConfig,
         inspection: FilterbankInspection | None = None,
     ) -> tuple[np.ndarray, FilterbankMetadata]:
+        source_path = Path(path).expanduser().resolve()
+        is_fits = source_path.suffix.lower() in {".fits", ".sf"}
 
-        path = Path(path).expanduser().resolve()
-        is_fits = path.suffix.lower() in {".fits", ".sf"}
-
-        # =====================================================
-        # PSRFITS PATH (STRICT GATE)
-        # =====================================================
         if is_fits:
-            if not _is_psrfits_file(path):
-                raise FormatDetectionError("Invalid FITS file", path=path)
-
-            # CRITICAL FIX: decide mode BEFORE anything else
-            is_fold = _psrchive_is_fold_mode(path)
-
-            if not is_fold:
+            is_search, obs_mode = _is_psrfits_search_mode(source_path)
+            is_fold, _ = _is_psrfits_fold_mode(source_path)
+            if is_fold:
+                return _load_folded_psrfits(source_path, config, inspection=inspection)
+            if not is_search:
                 raise FormatDetectionError(
-                    "PSRFITS search-mode not supported in this backend.",
-                    path=path,
+                    f"PSRFITS file is in {obs_mode!r} mode; FLITS supports SEARCH and PSR fold-mode data.",
+                    path=source_path,
+                )
+            fits_fallback = _psrfits_primary_fallback(source_path)
+        else:
+            fits_fallback = {}
+
+        filterbank_inspection = inspection
+        with _open_your(source_path) as reader:
+            header = reader.your_header
+            timing_metadata = _reader_timing_metadata(reader)
+            for key in (
+                "source_ra_deg",
+                "source_dec_deg",
+                "source_position_basis",
+                "barycentric_header_flag",
+                "pulsarcentric_header_flag",
+            ):
+                if key not in timing_metadata and key in fits_fallback:
+                    timing_metadata[key] = fits_fallback[key]
+            if filterbank_inspection is None:
+                telescope_id = _safe_int(getattr(reader, "telescope_id", None))
+                machine_id = _safe_int(getattr(reader, "machine_id", None))
+                source_name = _decode_source_name(getattr(reader, "source_name", None))
+                telescope_name = _decode_telescope_name(
+                    getattr(reader, "telescope_name", None)
+                    or getattr(header, "telescope", None)
+                )
+                if is_fits and source_name is None:
+                    source_name = fits_fallback.get("source_name")  # type: ignore[assignment]
+                if telescope_name is None:
+                    telescope_name = fits_fallback.get("telescope_name")  # type: ignore[assignment]
+                freq_lo_hint, freq_hi_hint = _peek_header_freq_range(header)
+                schema_version = "psrfits_search" if is_fits else "sigproc_search"
+                detected_preset_key, detection_basis = detect_preset(
+                    telescope_id,
+                    machine_id,
+                    telescope_name=telescope_name,
+                    schema_version=schema_version,
+                    freq_lo_mhz=freq_lo_hint,
+                    freq_hi_mhz=freq_hi_hint,
+                )
+                filterbank_inspection = FilterbankInspection(
+                    source_path=source_path,
+                    source_name=source_name,
+                    telescope_id=telescope_id,
+                    machine_id=machine_id,
+                    detected_preset_key=detected_preset_key,
+                    detection_basis=detection_basis,
+                    telescope_name=telescope_name,
+                    schema_version=schema_version,
+                    freq_lo_mhz=freq_lo_hint,
+                    freq_hi_mhz=freq_hi_hint,
+                    source_ra_deg=_safe_float(timing_metadata.get("source_ra_deg")),
+                    source_dec_deg=_safe_float(timing_metadata.get("source_dec_deg")),
+                    source_position_basis=timing_metadata.get("source_position_basis"),  # type: ignore[arg-type]
+                    time_scale="utc",
+                    time_reference_frame="topocentric",
+                    barycentric_header_flag=_safe_bool_flag(timing_metadata.get("barycentric_header_flag")),
+                    pulsarcentric_header_flag=_safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag")),
                 )
 
-            return _load_folded_psrchive(path, config)
+            tsamp = float(_coerce_header_field(
+                header, "tsamp",
+                fallback=fits_fallback.get("tsamp") if is_fits else None,
+                path=source_path,
+            ))
+            foff_raw = _coerce_header_field(header, "foff", path=source_path)
+            freqres = float(abs(float(foff_raw)))
+            start_mjd_raw = _coerce_header_field(
+                header, "tstart",
+                fallback=fits_fallback.get("tstart") if is_fits else None,
+                path=source_path,
+            )
+            start_mjd = float(start_mjd_raw)
+            bw = float(abs(float(_coerce_header_field(header, "bw", path=source_path))))
+            header_npol = max(1, int(_coerce_header_field(header, "npol", fallback=1, path=source_path)))
+            polarization_order = _normalise_polarization_order(
+                _decode_source_name(getattr(header, "poln_order", None))
+            )
+            fch1 = float(_coerce_header_field(header, "fch1", path=source_path))
+            nchans = int(_coerce_header_field(header, "nchans", path=source_path))
+            nspectra = int(_coerce_header_field(header, "nspectra", path=source_path))
 
-        # =====================================================
-        # SIGPROC PATH ONLY
-        # =====================================================
-        if path.suffix.lower() != ".fil":
-            raise FormatDetectionError(
-                "File is neither SIGPROC (.fil) nor supported PSRFITS fold.",
-                path=path,
+            freqs_mhz = fch1 + (float(foff_raw) * np.arange(nchans, dtype=float))
+            freq_lo = float(np.min(freqs_mhz))
+            freq_hi = float(np.max(freqs_mhz))
+            sefd_jy = config.sefd_jy
+            if sefd_jy is None:
+                sefd_jy = resolve_default_sefd_jy(config.preset_key, freq_lo, freq_hi)
+
+            read_start_sec = config.read_start_for_file(source_path.name)
+            nstart = min(max(int(read_start_sec / tsamp), 0), max(nspectra - 1, 0))
+            nread = max(1, int(nspectra - nstart))
+
+            if config.read_end_sec is not None:
+                nend = max(nstart + 1, int(config.read_end_sec / tsamp))
+                requested_nread = nend - nstart
+                nread = min(nread, requested_nread)
+
+            raw = reader.get_data(nstart, nread, npoln=header_npol)
+            stokes_i, effective_npol = _build_stokes_i(raw, polarization_order=polarization_order)
+            effective_npol = (
+                max(1, int(config.npol_override)) if config.npol_override is not None else effective_npol
             )
 
-        with _open_your(path) as reader:
-            h = reader.your_header
+            if stokes_i.shape[0] != nchans:
+                raise CorruptedDataError(
+                    f"Data channel count {stokes_i.shape[0]} does not match header nchans={nchans}",
+                    path=source_path,
+                )
 
-            tsamp = float(h.tsamp)
-            foff = float(h.foff)
-            fch1 = float(h.fch1)
-            nchans = int(h.nchans)
-            nspectra = int(h.nspectra)
+            stokes_i = dedisperse(stokes_i, config.dm, freqs_mhz, tsamp)
 
-            raw = reader.get_data(0, nspectra, npoln=1)
-            stokes_i = raw[:, 0, :].T
-
-            freqs = fch1 + foff * np.arange(nchans)
-
-            stokes_i = dedisperse(stokes_i, config.dm, freqs, tsamp)
-
-            stokes_i = normalize(
-                stokes_i,
-                stokes_i[:, int(0.8 * stokes_i.shape[1]):]
-            ).astype(np.float32)
+            tail_fraction = float(np.clip(config.normalization_tail_fraction, 0.05, 0.95))
+            offpulse_start = min(stokes_i.shape[1] - 1, int((1 - tail_fraction) * stokes_i.shape[1]))
+            offpulse = stokes_i[:, offpulse_start:]
+            stokes_i = normalize(stokes_i, offpulse).astype(np.float32, copy=False)
 
         metadata = FilterbankMetadata(
-            source_path=path,
-            source_name=path.stem,
-
+            source_path=source_path,
+            source_name=filterbank_inspection.source_name,
             tsamp=tsamp,
-            freqres=abs(foff),
-            start_mjd=float(h.tstart),
-
-            sefd_jy=config.sefd_jy or 1.0,
-            bandwidth_mhz=float(freqs.max() - freqs.min()),
-
-            npol=1,
-            freqs_mhz=freqs,
-            header_npol=1,
-
-            telescope_name="generic",
-
-            detected_preset_key="sigproc",
-            detection_basis="your_sigproc",
-
-            time_scale="utc",
-            time_reference_frame="topocentric",
+            freqres=freqres,
+            start_mjd=start_mjd,
+            read_start_sec=read_start_sec,
+            sefd_jy=sefd_jy,
+            bandwidth_mhz=bw,
+            npol=effective_npol,
+            freqs_mhz=freqs_mhz,
+            header_npol=header_npol,
+            polarization_order=polarization_order,
+            telescope_id=filterbank_inspection.telescope_id,
+            machine_id=filterbank_inspection.machine_id,
+            detected_preset_key=filterbank_inspection.detected_preset_key,
+            detection_basis=filterbank_inspection.detection_basis,
+            source_ra_deg=(
+                filterbank_inspection.source_ra_deg
+                if filterbank_inspection.source_ra_deg is not None
+                else _safe_float(timing_metadata.get("source_ra_deg"))
+            ),
+            source_dec_deg=(
+                filterbank_inspection.source_dec_deg
+                if filterbank_inspection.source_dec_deg is not None
+                else _safe_float(timing_metadata.get("source_dec_deg"))
+            ),
+            source_position_basis=(
+                filterbank_inspection.source_position_basis
+                or timing_metadata.get("source_position_basis")  # type: ignore[arg-type]
+            ),
+            time_scale=filterbank_inspection.time_scale or "utc",
+            time_reference_frame=filterbank_inspection.time_reference_frame or "topocentric",
+            barycentric_header_flag=(
+                filterbank_inspection.barycentric_header_flag
+                if filterbank_inspection.barycentric_header_flag is not None
+                else _safe_bool_flag(timing_metadata.get("barycentric_header_flag"))
+            ),
+            pulsarcentric_header_flag=(
+                filterbank_inspection.pulsarcentric_header_flag
+                if filterbank_inspection.pulsarcentric_header_flag is not None
+                else _safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag"))
+            ),
+            dedispersion_reference_frequency_mhz=(
+                float(np.max(freqs_mhz)) if abs(float(config.dm)) > 0.0 else None
+            ),
+            dedispersion_reference_basis=(
+                "flits_integer_bin_dedispersion_max_frequency" if abs(float(config.dm)) > 0.0 else None
+            ),
         )
-
         return stokes_i, validate_metadata(metadata)
 
 

--- a/flits/io/your_reader.py
+++ b/flits/io/your_reader.py
@@ -5,12 +5,14 @@ import os
 import shutil
 import struct
 import tempfile
+import logging
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import ClassVar, Iterator
 
 import numpy as np
+import psrchive
 
 from flits.io.errors import (
     CorruptedDataError,
@@ -20,667 +22,265 @@ from flits.io.errors import (
 from flits.io.reader import FilterbankInspection
 from flits.io.validation import validate_metadata
 from flits.models import FilterbankMetadata
-from flits.settings import ObservationConfig, detect_preset, resolve_default_sefd_jy
+from flits.settings import ObservationConfig
 from flits.signal import dedisperse, normalize
 
+logger = logging.getLogger(__name__)
+
+# ============================================================
+# Optional dependency: your (SIGPROC backend)
+# ============================================================
 try:
     import your as _your
     _YOUR_IMPORT_ERROR: Exception | None = None
-except Exception as exc:  # pragma: no cover - depends on optional runtime stack
+except Exception as exc:
     _your = SimpleNamespace(Your=None)
     _YOUR_IMPORT_ERROR = exc
 
 your = _your
 
-
 _SIGPROC_MAGIC = struct.pack("i", 12) + b"HEADER_START"
 _FITS_MAGIC = b"SIMPLE  ="
 
+
+# ============================================================
+# Utilities
+# ============================================================
 
 def _is_mmap_deadlock(exc: BaseException) -> bool:
     return isinstance(exc, OSError) and exc.errno == errno.EDEADLK
 
 
-def _close_reader(reader: object | None) -> None:
-    if reader is None:
-        return
-    fp = getattr(reader, "fp", None)
-    if fp is not None and not getattr(fp, "closed", True):
-        try:
-            fp.close()
-        except OSError:
-            pass
-
-
 @contextmanager
 def _open_your(source_path: Path) -> Iterator[object]:
-    """Open a your.Your reader, falling back to a local copy on mmap EDEADLK.
-
-    Some network/FUSE mounts (sshfs, SMB, iCloud) return EDEADLK from mmap();
-    copying to a local tempdir sidesteps this without changing the read path.
-    """
     if your.Your is None:
-        raise RuntimeError(
-            "The 'your' package is unavailable in the active environment."
-        ) from _YOUR_IMPORT_ERROR
+        raise RuntimeError("SIGPROC backend 'your' unavailable") from _YOUR_IMPORT_ERROR
 
-    temp_path: Path | None = None
-    reader: object | None = None
+    tmp_path: Path | None = None
+    reader = None
+
     try:
         try:
             reader = your.Your(str(source_path))
         except OSError as exc:
             if not _is_mmap_deadlock(exc):
                 raise
-            tmp_dir = Path(tempfile.gettempdir())
-            temp_path = tmp_dir / f"flits_fb_{os.getpid()}_{source_path.name}"
-            shutil.copyfile(source_path, temp_path)
-            reader = your.Your(str(temp_path))
+
+            tmp_path = Path(tempfile.gettempdir()) / f"flits_{os.getpid()}_{source_path.name}"
+            shutil.copyfile(source_path, tmp_path)
+            reader = your.Your(str(tmp_path))
+
         yield reader
+
     finally:
-        _close_reader(reader)
-        if temp_path is not None:
+        if reader and hasattr(reader, "fp"):
             try:
-                temp_path.unlink(missing_ok=True)
-            except OSError:
+                reader.fp.close()
+            except Exception:
+                pass
+
+        if tmp_path:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
                 pass
 
 
-def _normalise_polarization_order(value: str | None) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text.upper() if text else None
+# ============================================================
+# PSRFITS HANDLING (STRICT)
+# ============================================================
 
-
-def _build_stokes_i(raw: np.ndarray, polarization_order: str | None = None) -> tuple[np.ndarray, int]:
-    normalized_order = _normalise_polarization_order(polarization_order)
-    if raw.ndim == 2:
-        effective_npol = 2 if normalized_order == "IQUV" else 1
-        return raw.T, effective_npol
-    aa = raw[:, 0, :].T
-    if normalized_order == "IQUV" and raw.shape[1] >= 4:
-        return aa, 2
-    if raw.shape[1] >= 2:
-        bb = raw[:, 1, :].T
-        return aa + bb, 2
-    return aa, 1
-
-
-def _decode_source_name(value: object) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    text = str(value)
-    return text or None
-
-
-def _safe_int(value: object) -> int | None:
-    if value is None:
-        return None
+def _is_psrfits_file(path: Path) -> bool:
+    """Cheap + robust FITS detection."""
     try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _safe_float(value: object) -> float | None:
-    if value is None:
-        return None
-    try:
-        result = float(value)
-    except (TypeError, ValueError):
-        return None
-    return result if np.isfinite(result) else None
-
-
-def _safe_bool_flag(value: object) -> bool | None:
-    if value is None:
-        return None
-    try:
-        return bool(int(value))
-    except (TypeError, ValueError):
-        text = str(value).strip().lower()
-        if text in {"true", "t", "yes", "y"}:
-            return True
-        if text in {"false", "f", "no", "n"}:
-            return False
-        return None
-
-
-def _first_present(*values: object) -> object | None:
-    for value in values:
-        if value is not None:
-            return value
-    return None
-
-
-def _packed_sexagesimal_to_deg(value: object, *, is_ra: bool) -> float | None:
-    numeric = _safe_float(value)
-    if numeric is None:
-        return None
-    sign = -1.0 if numeric < 0 else 1.0
-    current = abs(numeric)
-    first = int(current // 10000)
-    minutes = int((current - first * 10000) // 100)
-    seconds = current - first * 10000 - minutes * 100
-    if minutes >= 60 or seconds >= 60:
-        return None
-    degrees = first + minutes / 60.0 + seconds / 3600.0
-    if is_ra:
-        return float(degrees * 15.0)
-    return float(sign * degrees)
-
-
-def _coerce_coordinate_deg(value: object, *, is_ra: bool) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, bytes):
-        value = value.decode("utf-8", errors="replace")
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return None
-        try:
-            from astropy import units as u
-            from astropy.coordinates import Angle
-
-            unit = u.hourangle if is_ra else u.deg
-            return float(Angle(text, unit=unit).deg)
-        except Exception:
-            return _safe_float(text)
-    numeric = _safe_float(value)
-    if numeric is None:
-        return None
-    if abs(numeric) > 360.0:
-        return _packed_sexagesimal_to_deg(numeric, is_ra=is_ra)
-    return numeric
-
-
-def _reader_timing_metadata(reader: object) -> dict[str, object]:
-    header = getattr(reader, "your_header", None)
-    metadata: dict[str, object] = {}
-    for obj in (reader, header):
-        if obj is None:
-            continue
-        if "source_ra_deg" not in metadata:
-            ra = _coerce_coordinate_deg(
-                _first_present(
-                    getattr(obj, "ra_deg", None),
-                    getattr(obj, "src_raj", None),
-                    getattr(obj, "RAJ", None),
-                ),
-                is_ra=True,
-            )
-            if ra is not None:
-                metadata["source_ra_deg"] = ra
-        if "source_dec_deg" not in metadata:
-            dec = _coerce_coordinate_deg(
-                _first_present(
-                    getattr(obj, "dec_deg", None),
-                    getattr(obj, "src_dej", None),
-                    getattr(obj, "DECJ", None),
-                ),
-                is_ra=False,
-            )
-            if dec is not None:
-                metadata["source_dec_deg"] = dec
-        if "barycentric_header_flag" not in metadata:
-            bary = _safe_bool_flag(getattr(obj, "barycentric", None))
-            if bary is not None:
-                metadata["barycentric_header_flag"] = bary
-        if "pulsarcentric_header_flag" not in metadata:
-            pulsar = _safe_bool_flag(getattr(obj, "pulsarcentric", None))
-            if pulsar is not None:
-                metadata["pulsarcentric_header_flag"] = pulsar
-    if "source_ra_deg" in metadata and "source_dec_deg" in metadata:
-        metadata["source_position_basis"] = "reader_header"
-    return metadata
-
-
-def _peek_bytes(path: Path, n: int) -> bytes:
-    try:
-        with open(path, "rb") as handle:
-            return handle.read(n)
-    except OSError:
-        return b""
-
-
-def _is_psrfits_search_mode(path: Path) -> tuple[bool, str | None]:
-    """Inspect a FITS primary header to detect fold-mode PSRFITS.
-
-    Returns (is_search_mode, obs_mode_value). If astropy isn't available, returns
-    (True, None) optimistically — `your` will fail informatively on fold files.
-    """
-    try:
-        from astropy.io import fits
-    except Exception:
-        return True, None
-
-    try:
-        with fits.open(path, memmap=False) as hdul:
-            primary = hdul[0].header
-            obs_mode = str(primary.get("OBS_MODE", "")).strip().upper()
-    except Exception:
-        return True, None
-
-    if not obs_mode:
-        return True, None
-    return obs_mode.startswith("SEARCH"), obs_mode
-
-
-def _looks_like_psrfits(path: Path) -> bool:
-    """Return True only for FITS files that look structurally like PSRFITS."""
-    try:
-        from astropy.io import fits
-    except Exception:
-        return False
-
-    try:
-        with fits.open(path, memmap=False) as hdul:
-            primary = hdul[0].header
-            fitstype = str(primary.get("FITSTYPE", "")).strip().upper()
-            obs_mode = str(primary.get("OBS_MODE", "")).strip().upper()
-            subint = next(
-                (
-                    hdu
-                    for hdu in hdul[1:]
-                    if str(hdu.header.get("EXTNAME", "")).strip().upper() == "SUBINT"
-                ),
-                None,
-            )
-            if subint is None:
-                return False
-
-            subint_header = subint.header
-            subint_keywords_present = all(
-                key in subint_header for key in ("TBIN", "NCHAN", "NPOL")
-            )
-            primary_looks_psrfits = (
-                "PSRFITS" in fitstype or "STT_IMJD" in primary or "STT_SMJD" in primary
-            )
-            mode_looks_search = (not obs_mode) or obs_mode.startswith("SEARCH")
-            return mode_looks_search and (primary_looks_psrfits or subint_keywords_present)
+        head = path.read_bytes()[:16]
+        return head.startswith(_FITS_MAGIC)
     except Exception:
         return False
 
 
-def _psrfits_primary_fallback(path: Path) -> dict[str, object]:
-    """Extract commonly-missing PSRFITS metadata directly from the FITS headers.
-
-    `your`'s PSRFITS handling occasionally leaves `tstart`, `telescope_id`, or
-    `source_name` unset on non-canonical files (some MeerKAT/Parkes variants).
-    This pulls them from the primary and SUBINT headers via astropy.
-    """
+def _psrchive_is_fold_mode(path: Path) -> bool:
+    """Single authoritative check using PSRCHIVE."""
     try:
-        from astropy.io import fits
+        ar = psrchive.Archive_load(str(path))
+        ar_type = str(ar.get_type()).lower() if ar.get_type() else ""
+        return "fold" in ar_type
     except Exception:
-        return {}
-
-    out: dict[str, object] = {}
-    try:
-        with fits.open(path, memmap=False) as hdul:
-            primary = hdul[0].header
-            stt_imjd = primary.get("STT_IMJD")
-            stt_smjd = primary.get("STT_SMJD")
-            stt_offs = primary.get("STT_OFFS", 0.0) or 0.0
-            if stt_imjd is not None and stt_smjd is not None:
-                out["tstart"] = float(stt_imjd) + (float(stt_smjd) + float(stt_offs)) / 86400.0
-            telescope = primary.get("TELESCOP")
-            if telescope:
-                out["telescope_name"] = str(telescope).strip()
-            source = primary.get("SRC_NAME")
-            if source:
-                out["source_name"] = str(source).strip()
-            ra = None
-            for candidate in (primary.get("RAJ"), primary.get("RA"), primary.get("OBJCTRA")):
-                ra = _coerce_coordinate_deg(candidate, is_ra=True)
-                if ra is not None:
-                    break
-            dec = None
-            for candidate in (primary.get("DECJ"), primary.get("DEC"), primary.get("OBJCTDEC")):
-                dec = _coerce_coordinate_deg(candidate, is_ra=False)
-                if dec is not None:
-                    break
-            if ra is not None and dec is not None:
-                out["source_ra_deg"] = float(ra)
-                out["source_dec_deg"] = float(dec)
-                out["source_position_basis"] = "psrfits_primary_header"
-            bary = _safe_bool_flag(_first_present(primary.get("BARYCENT"), primary.get("BARYCORR")))
-            if bary is not None:
-                out["barycentric_header_flag"] = bary
-            pulsar = _safe_bool_flag(_first_present(primary.get("PULSAREN"), primary.get("PULSARC")))
-            if pulsar is not None:
-                out["pulsarcentric_header_flag"] = pulsar
-    except Exception:
-        return out
-    return out
+        return False
 
 
-def _decode_telescope_name(value: object) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, bytes):
-        text = value.decode("utf-8", errors="replace").strip()
-    else:
-        text = str(value).strip()
-    return text or None
+def _load_folded_psrchive(
+    path: Path,
+    config: ObservationConfig,
+) -> tuple[np.ndarray, FilterbankMetadata]:
+
+    logger.info(f"[PSRCHIVE] folded load: {path.name}")
+
+    ar = psrchive.Archive_load(str(path))
+    ar.remove_baseline()
+
+    if not ar.get_dedispersed():
+        ar.dedisperse()
+
+    dm = float(ar.get_dispersion_measure())
+    period = float(ar[0].get_folding_period())
+
+    data = ar.get_data()  # (subint, pol, chan, bin)
+
+    # → Stokes I
+    data = data[:, 0, :, :]        # (subint, chan, bin)
+    dyn = np.mean(data, axis=2)    # (subint, chan)
+    dyn = dyn.T                    # (chan, subint)
+
+    freqs = np.asarray(ar.get_frequencies(), dtype=float)
+    order = np.argsort(freqs)
+
+    freqs = freqs[order]
+    dyn = dyn[order, :]
+
+    dyn = normalize(dyn, dyn[:, int(0.8 * dyn.shape[1]):]).astype(np.float32)
+
+    metadata = FilterbankMetadata(
+        source_path=path,
+        source_name=path.stem,
+
+        tsamp=period,
+        freqres=float(abs(freqs[1] - freqs[0])) if len(freqs) > 1 else 0.0,
+        start_mjd=float(ar.get_start_time().in_days()) if ar.get_start_time() else 0.0,
+
+        sefd_jy=config.sefd_jy or 1.0,
+        bandwidth_mhz=float(freqs.max() - freqs.min()),
+
+        npol=1,
+        freqs_mhz=freqs,
+        header_npol=1,
+
+        telescope_name=str(ar.get_telescope()) if ar.get_telescope() else "unknown",
+
+        detected_preset_key="psrchive_fold",
+        detection_basis="folded_psrfits",
+
+        time_scale="folded",
+        time_reference_frame="topocentric",
+    )
+
+    return dyn, validate_metadata(metadata)
 
 
-def _peek_header_freq_range(header: object) -> tuple[float | None, float | None]:
-    """Return (lo, hi) MHz from a `your` header, or (None, None) if any field is missing."""
-    fch1 = getattr(header, "fch1", None)
-    foff = getattr(header, "foff", None)
-    nchans = getattr(header, "nchans", None)
-    try:
-        if fch1 is None or foff is None or nchans is None:
-            return (None, None)
-        fch1_f = float(fch1)
-        foff_f = float(foff)
-        nchans_i = int(nchans)
-    except (TypeError, ValueError):
-        return (None, None)
-    if nchans_i <= 0 or not np.isfinite(fch1_f) or not np.isfinite(foff_f):
-        return (None, None)
-    lo = fch1_f
-    hi = fch1_f + foff_f * (nchans_i - 1)
-    return (min(lo, hi), max(lo, hi))
-
-
-def _coerce_header_field(
-    header: object,
-    name: str,
-    *,
-    fallback: object | None = None,
-    required: bool = True,
-    path: Path | None = None,
-) -> object:
-    value = getattr(header, name, None)
-    if value is None or (isinstance(value, float) and not np.isfinite(value)):
-        if fallback is not None:
-            return fallback
-        if required:
-            raise MetadataMissingError(
-                f"Header field {name!r} missing and no fallback available",
-                path=path,
-                fields=(name,),
-            )
-    return value
-
+# ============================================================
+# MAIN READER
+# ============================================================
 
 class YourFilterbankReader:
-    """Reader backed by the `your` library for SIGPROC .fil and PSRFITS search-mode.
+    """
+    Clean, strict, non-ambiguous reader:
 
-    Registered for both `.fil` (SIGPROC) and `.fits` / `.sf` (PSRFITS). PSRFITS
-    fold-mode files are rejected explicitly — FLITS is a burst tool, not a
-    timing tool. Missing PSRFITS header fields are patched in from the FITS
-    primary header via astropy where possible.
+    SIGPROC (.fil) → your backend
+    PSRFITS fold   → psrchive ONLY
+    PSRFITS search → REJECTED (explicit)
     """
 
     format_id: ClassVar[str] = "sigproc"
-    format_id_aliases: ClassVar[tuple[str, ...]] = ("psrfits", "your", "fil", "fits")
     extensions: ClassVar[tuple[str, ...]] = (".fil", ".fits", ".sf")
 
+    # --------------------------------------------------------
     def sniff(self, path: Path) -> bool:
-        head = _peek_bytes(path, 16)
+        try:
+            head = path.read_bytes()[:16]
+        except Exception:
+            return False
+
         if head.startswith(_SIGPROC_MAGIC):
             return True
+
         if head.startswith(_FITS_MAGIC):
-            return _looks_like_psrfits(path)
+            return _is_psrfits_file(path)
+
         return False
 
-    def inspect(self, path: Path) -> FilterbankInspection:
-        source_path = Path(path).expanduser().resolve()
-        is_fits = source_path.suffix.lower() in {".fits", ".sf"}
-
-        if is_fits:
-            is_search, obs_mode = _is_psrfits_search_mode(source_path)
-            if not is_search:
-                raise FormatDetectionError(
-                    f"PSRFITS file is in {obs_mode!r} mode; FLITS requires SEARCH-mode data.",
-                    path=source_path,
-                )
-
-        fits_fallback = _psrfits_primary_fallback(source_path) if is_fits else {}
-
-        with _open_your(source_path) as reader:
-            telescope_id = _safe_int(getattr(reader, "telescope_id", None))
-            machine_id = _safe_int(getattr(reader, "machine_id", None))
-            source_name = _decode_source_name(getattr(reader, "source_name", None))
-            telescope_name = _decode_telescope_name(
-                getattr(reader, "telescope_name", None)
-                or getattr(getattr(reader, "your_header", None), "telescope", None)
-            )
-            freq_lo, freq_hi = _peek_header_freq_range(getattr(reader, "your_header", None))
-            timing_metadata = _reader_timing_metadata(reader)
-
-        if is_fits and source_name is None:
-            source_name = fits_fallback.get("source_name")  # type: ignore[assignment]
-        if telescope_name is None:
-            telescope_name = fits_fallback.get("telescope_name")  # type: ignore[assignment]
-        for key in (
-            "source_ra_deg",
-            "source_dec_deg",
-            "source_position_basis",
-            "barycentric_header_flag",
-            "pulsarcentric_header_flag",
-        ):
-            if key not in timing_metadata and key in fits_fallback:
-                timing_metadata[key] = fits_fallback[key]
-
-        schema_version = "psrfits_search" if is_fits else "sigproc_search"
-
-        detected_preset_key, detection_basis = detect_preset(
-            telescope_id,
-            machine_id,
-            telescope_name=telescope_name,
-            schema_version=schema_version,
-            freq_lo_mhz=freq_lo,
-            freq_hi_mhz=freq_hi,
-        )
-        return FilterbankInspection(
-            source_path=source_path,
-            source_name=source_name,
-            telescope_id=telescope_id,
-            machine_id=machine_id,
-            detected_preset_key=detected_preset_key,
-            detection_basis=detection_basis,
-            telescope_name=telescope_name,
-            schema_version=schema_version,
-            freq_lo_mhz=freq_lo,
-            freq_hi_mhz=freq_hi,
-            source_ra_deg=_safe_float(timing_metadata.get("source_ra_deg")),
-            source_dec_deg=_safe_float(timing_metadata.get("source_dec_deg")),
-            source_position_basis=timing_metadata.get("source_position_basis"),  # type: ignore[arg-type]
-            time_scale="utc",
-            time_reference_frame="topocentric",
-            barycentric_header_flag=_safe_bool_flag(timing_metadata.get("barycentric_header_flag")),
-            pulsarcentric_header_flag=_safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag")),
-        )
-
+    # --------------------------------------------------------
     def load(
         self,
         path: Path,
         config: ObservationConfig,
         inspection: FilterbankInspection | None = None,
     ) -> tuple[np.ndarray, FilterbankMetadata]:
-        source_path = Path(path).expanduser().resolve()
-        is_fits = source_path.suffix.lower() in {".fits", ".sf"}
 
+        path = Path(path).expanduser().resolve()
+        is_fits = path.suffix.lower() in {".fits", ".sf"}
+
+        # =====================================================
+        # PSRFITS PATH (STRICT GATE)
+        # =====================================================
         if is_fits:
-            is_search, obs_mode = _is_psrfits_search_mode(source_path)
-            if not is_search:
+            if not _is_psrfits_file(path):
+                raise FormatDetectionError("Invalid FITS file", path=path)
+
+            # CRITICAL FIX: decide mode BEFORE anything else
+            is_fold = _psrchive_is_fold_mode(path)
+
+            if not is_fold:
                 raise FormatDetectionError(
-                    f"PSRFITS file is in {obs_mode!r} mode; FLITS requires SEARCH-mode data.",
-                    path=source_path,
-                )
-            fits_fallback = _psrfits_primary_fallback(source_path)
-        else:
-            fits_fallback = {}
-
-        filterbank_inspection = inspection
-        with _open_your(source_path) as reader:
-            header = reader.your_header
-            timing_metadata = _reader_timing_metadata(reader)
-            for key in (
-                "source_ra_deg",
-                "source_dec_deg",
-                "source_position_basis",
-                "barycentric_header_flag",
-                "pulsarcentric_header_flag",
-            ):
-                if key not in timing_metadata and key in fits_fallback:
-                    timing_metadata[key] = fits_fallback[key]
-            if filterbank_inspection is None:
-                telescope_id = _safe_int(getattr(reader, "telescope_id", None))
-                machine_id = _safe_int(getattr(reader, "machine_id", None))
-                source_name = _decode_source_name(getattr(reader, "source_name", None))
-                telescope_name = _decode_telescope_name(
-                    getattr(reader, "telescope_name", None)
-                    or getattr(header, "telescope", None)
-                )
-                if is_fits and source_name is None:
-                    source_name = fits_fallback.get("source_name")  # type: ignore[assignment]
-                if telescope_name is None:
-                    telescope_name = fits_fallback.get("telescope_name")  # type: ignore[assignment]
-                freq_lo_hint, freq_hi_hint = _peek_header_freq_range(header)
-                schema_version = "psrfits_search" if is_fits else "sigproc_search"
-                detected_preset_key, detection_basis = detect_preset(
-                    telescope_id,
-                    machine_id,
-                    telescope_name=telescope_name,
-                    schema_version=schema_version,
-                    freq_lo_mhz=freq_lo_hint,
-                    freq_hi_mhz=freq_hi_hint,
-                )
-                filterbank_inspection = FilterbankInspection(
-                    source_path=source_path,
-                    source_name=source_name,
-                    telescope_id=telescope_id,
-                    machine_id=machine_id,
-                    detected_preset_key=detected_preset_key,
-                    detection_basis=detection_basis,
-                    telescope_name=telescope_name,
-                    schema_version=schema_version,
-                    freq_lo_mhz=freq_lo_hint,
-                    freq_hi_mhz=freq_hi_hint,
-                    source_ra_deg=_safe_float(timing_metadata.get("source_ra_deg")),
-                    source_dec_deg=_safe_float(timing_metadata.get("source_dec_deg")),
-                    source_position_basis=timing_metadata.get("source_position_basis"),  # type: ignore[arg-type]
-                    time_scale="utc",
-                    time_reference_frame="topocentric",
-                    barycentric_header_flag=_safe_bool_flag(timing_metadata.get("barycentric_header_flag")),
-                    pulsarcentric_header_flag=_safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag")),
+                    "PSRFITS search-mode not supported in this backend.",
+                    path=path,
                 )
 
-            tsamp = float(_coerce_header_field(
-                header, "tsamp",
-                fallback=fits_fallback.get("tsamp") if is_fits else None,
-                path=source_path,
-            ))
-            foff_raw = _coerce_header_field(header, "foff", path=source_path)
-            freqres = float(abs(float(foff_raw)))
-            start_mjd_raw = _coerce_header_field(
-                header, "tstart",
-                fallback=fits_fallback.get("tstart") if is_fits else None,
-                path=source_path,
-            )
-            start_mjd = float(start_mjd_raw)
-            bw = float(abs(float(_coerce_header_field(header, "bw", path=source_path))))
-            header_npol = max(1, int(_coerce_header_field(header, "npol", fallback=1, path=source_path)))
-            polarization_order = _normalise_polarization_order(
-                _decode_source_name(getattr(header, "poln_order", None))
-            )
-            fch1 = float(_coerce_header_field(header, "fch1", path=source_path))
-            nchans = int(_coerce_header_field(header, "nchans", path=source_path))
-            nspectra = int(_coerce_header_field(header, "nspectra", path=source_path))
+            return _load_folded_psrchive(path, config)
 
-            freqs_mhz = fch1 + (float(foff_raw) * np.arange(nchans, dtype=float))
-            freq_lo = float(np.min(freqs_mhz))
-            freq_hi = float(np.max(freqs_mhz))
-            sefd_jy = config.sefd_jy
-            if sefd_jy is None:
-                sefd_jy = resolve_default_sefd_jy(config.preset_key, freq_lo, freq_hi)
-
-            read_start_sec = config.read_start_for_file(source_path.name)
-            nstart = min(max(int(read_start_sec / tsamp), 0), max(nspectra - 1, 0))
-            nread = max(1, int(nspectra - nstart))
-
-            if config.read_end_sec is not None:
-                nend = max(nstart + 1, int(config.read_end_sec / tsamp))
-                requested_nread = nend - nstart
-                nread = min(nread, requested_nread)
-
-            raw = reader.get_data(nstart, nread, npoln=header_npol)
-            stokes_i, effective_npol = _build_stokes_i(raw, polarization_order=polarization_order)
-            effective_npol = (
-                max(1, int(config.npol_override)) if config.npol_override is not None else effective_npol
+        # =====================================================
+        # SIGPROC PATH ONLY
+        # =====================================================
+        if path.suffix.lower() != ".fil":
+            raise FormatDetectionError(
+                "File is neither SIGPROC (.fil) nor supported PSRFITS fold.",
+                path=path,
             )
 
-            if stokes_i.shape[0] != nchans:
-                raise CorruptedDataError(
-                    f"Data channel count {stokes_i.shape[0]} does not match header nchans={nchans}",
-                    path=source_path,
-                )
+        with _open_your(path) as reader:
+            h = reader.your_header
 
-            stokes_i = dedisperse(stokes_i, config.dm, freqs_mhz, tsamp)
+            tsamp = float(h.tsamp)
+            foff = float(h.foff)
+            fch1 = float(h.fch1)
+            nchans = int(h.nchans)
+            nspectra = int(h.nspectra)
 
-            tail_fraction = float(np.clip(config.normalization_tail_fraction, 0.05, 0.95))
-            offpulse_start = min(stokes_i.shape[1] - 1, int((1 - tail_fraction) * stokes_i.shape[1]))
-            offpulse = stokes_i[:, offpulse_start:]
-            stokes_i = normalize(stokes_i, offpulse).astype(np.float32, copy=False)
+            raw = reader.get_data(0, nspectra, npoln=1)
+            stokes_i = raw[:, 0, :].T
+
+            freqs = fch1 + foff * np.arange(nchans)
+
+            stokes_i = dedisperse(stokes_i, config.dm, freqs, tsamp)
+
+            stokes_i = normalize(
+                stokes_i,
+                stokes_i[:, int(0.8 * stokes_i.shape[1]):]
+            ).astype(np.float32)
 
         metadata = FilterbankMetadata(
-            source_path=source_path,
-            source_name=filterbank_inspection.source_name,
+            source_path=path,
+            source_name=path.stem,
+
             tsamp=tsamp,
-            freqres=freqres,
-            start_mjd=start_mjd,
-            read_start_sec=read_start_sec,
-            sefd_jy=sefd_jy,
-            bandwidth_mhz=bw,
-            npol=effective_npol,
-            freqs_mhz=freqs_mhz,
-            header_npol=header_npol,
-            polarization_order=polarization_order,
-            telescope_id=filterbank_inspection.telescope_id,
-            machine_id=filterbank_inspection.machine_id,
-            detected_preset_key=filterbank_inspection.detected_preset_key,
-            detection_basis=filterbank_inspection.detection_basis,
-            source_ra_deg=(
-                filterbank_inspection.source_ra_deg
-                if filterbank_inspection.source_ra_deg is not None
-                else _safe_float(timing_metadata.get("source_ra_deg"))
-            ),
-            source_dec_deg=(
-                filterbank_inspection.source_dec_deg
-                if filterbank_inspection.source_dec_deg is not None
-                else _safe_float(timing_metadata.get("source_dec_deg"))
-            ),
-            source_position_basis=(
-                filterbank_inspection.source_position_basis
-                or timing_metadata.get("source_position_basis")  # type: ignore[arg-type]
-            ),
-            time_scale=filterbank_inspection.time_scale or "utc",
-            time_reference_frame=filterbank_inspection.time_reference_frame or "topocentric",
-            barycentric_header_flag=(
-                filterbank_inspection.barycentric_header_flag
-                if filterbank_inspection.barycentric_header_flag is not None
-                else _safe_bool_flag(timing_metadata.get("barycentric_header_flag"))
-            ),
-            pulsarcentric_header_flag=(
-                filterbank_inspection.pulsarcentric_header_flag
-                if filterbank_inspection.pulsarcentric_header_flag is not None
-                else _safe_bool_flag(timing_metadata.get("pulsarcentric_header_flag"))
-            ),
-            dedispersion_reference_frequency_mhz=(
-                float(np.max(freqs_mhz)) if abs(float(config.dm)) > 0.0 else None
-            ),
-            dedispersion_reference_basis=(
-                "flits_integer_bin_dedispersion_max_frequency" if abs(float(config.dm)) > 0.0 else None
-            ),
+            freqres=abs(foff),
+            start_mjd=float(h.tstart),
+
+            sefd_jy=config.sefd_jy or 1.0,
+            bandwidth_mhz=float(freqs.max() - freqs.min()),
+
+            npol=1,
+            freqs_mhz=freqs,
+            header_npol=1,
+
+            telescope_name="generic",
+
+            detected_preset_key="sigproc",
+            detection_basis="your_sigproc",
+
+            time_scale="utc",
+            time_reference_frame="topocentric",
         )
+
         return stokes_i, validate_metadata(metadata)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,85 @@ def _write_psrfits(
         produced.rename(path)
 
 
+def _write_folded_psrfits(
+    path: Path,
+    data: np.ndarray,
+    tsamp_s: float,
+    fch1_mhz: float,
+    foff_mhz: float,
+    tstart_mjd: float,
+    source_name: str,
+) -> None:
+    fits = pytest.importorskip("astropy.io.fits")
+
+    nchan, nbin = data.shape
+    npol = 1
+    stt_imjd = int(tstart_mjd)
+    stt_seconds = (float(tstart_mjd) - stt_imjd) * 86400.0
+    stt_smjd = int(stt_seconds)
+    stt_offs = stt_seconds - stt_smjd
+
+    packed = np.rint(data).astype(">i2").reshape(1, npol, nchan, nbin)
+    freqs = fch1_mhz + (foff_mhz * np.arange(nchan, dtype=float))
+    period = float(tsamp_s) * nbin
+
+    primary = fits.PrimaryHDU()
+    primary.header["FITSTYPE"] = "PSRFITS"
+    primary.header["OBS_MODE"] = "PSR"
+    primary.header["SRC_NAME"] = source_name
+    primary.header["TELESCOP"] = "SYNTH"
+    primary.header["OBSFREQ"] = float(np.mean(freqs))
+    primary.header["OBSBW"] = float(foff_mhz * nchan)
+    primary.header["OBSNCHAN"] = nchan
+    primary.header["STT_IMJD"] = stt_imjd
+    primary.header["STT_SMJD"] = stt_smjd
+    primary.header["STT_OFFS"] = stt_offs
+    primary.header["RAJ"] = "12:34:56.78"
+    primary.header["DECJ"] = "-12:34:56.78"
+
+    subint = fits.BinTableHDU.from_columns(
+        [
+            fits.Column(name="PERIOD", format="D", array=np.array([period])),
+            fits.Column(name="DAT_FREQ", format=f"{nchan}D", array=freqs.reshape(1, nchan)),
+            fits.Column(name="DAT_WTS", format=f"{nchan}E", array=np.ones((1, nchan), dtype=">f4")),
+            fits.Column(name="DAT_OFFS", format=f"{nchan}E", array=np.zeros((1, nchan), dtype=">f4")),
+            fits.Column(name="DAT_SCL", format=f"{nchan}E", array=np.ones((1, nchan), dtype=">f4")),
+            fits.Column(
+                name="DATA",
+                format=f"{npol * nchan * nbin}I",
+                dim=f"({nbin},{nchan},{npol})",
+                array=packed,
+            ),
+        ],
+        name="SUBINT",
+    )
+    subint.header["NBIN"] = nbin
+    subint.header["NCHAN"] = nchan
+    subint.header["NPOL"] = npol
+    subint.header["TBIN"] = float(tsamp_s)
+    subint.header["CHAN_BW"] = float(foff_mhz)
+    subint.header["POL_TYPE"] = "INTEN"
+
+    psrparam = fits.BinTableHDU.from_columns(
+        [
+            fits.Column(
+                name="PARAM",
+                format="96A",
+                array=np.array(
+                    [
+                        f"PSRJ {source_name}",
+                        f"P0 {period:.12g}",
+                        "DM 0.0",
+                    ],
+                    dtype="S96",
+                ),
+            )
+        ],
+        name="PSRPARAM",
+    )
+    fits.HDUList([primary, psrparam, subint]).writeto(path)
+
+
 @pytest.fixture
 def synthetic_waterfall(request, tmp_path: Path) -> SyntheticWaterfall:
     """Generate a synthetic burst and materialize it in the requested format.
@@ -275,6 +354,17 @@ def synthetic_waterfall(request, tmp_path: Path) -> SyntheticWaterfall:
     elif format_id == "psrfits":
         path = tmp_path / "synthetic.fits"
         _write_psrfits(path, sigproc_path)
+    elif format_id == "psrfits_fold":
+        path = tmp_path / "synthetic_fold.fits"
+        _write_folded_psrfits(
+            path,
+            data,
+            tsamp_s=tsamp_s,
+            fch1_mhz=fch1_mhz,
+            foff_mhz=foff_mhz,
+            tstart_mjd=tstart_mjd,
+            source_name=source_name,
+        )
     elif format_id == "chime_bbdata_beamformed":
         path = tmp_path / "synthetic_beamformed.h5"
         _write_chime_bbdata_beamformed(

--- a/tests/test_io_readers.py
+++ b/tests/test_io_readers.py
@@ -22,7 +22,7 @@ from flits.models import FilterbankMetadata
 from flits.settings import ObservationConfig
 
 
-_ALL_FORMATS = ["sigproc", "chime_hdf5", "psrfits", "chime_bbdata_beamformed"]
+_ALL_FORMATS = ["sigproc", "chime_hdf5", "psrfits", "psrfits_fold", "chime_bbdata_beamformed"]
 
 
 @pytest.mark.parametrize("synthetic_waterfall", _ALL_FORMATS, indirect=True)
@@ -32,6 +32,7 @@ def test_detect_reader_picks_correct_format(synthetic_waterfall):
         "sigproc": "sigproc",
         "chime_hdf5": "chime_hdf5",
         "psrfits": "sigproc",  # shared YourFilterbankReader
+        "psrfits_fold": "sigproc",  # shared YourFilterbankReader
         "chime_bbdata_beamformed": "chime_hdf5",
     }[synthetic_waterfall.format_id]
     assert reader.format_id == expected
@@ -70,6 +71,24 @@ def test_round_trip_metadata(synthetic_waterfall):
     collapsed = data.mean(axis=0)
     peak_bin = int(np.argmax(collapsed))
     assert abs(peak_bin - synthetic_waterfall.burst_time_idx) < 5
+
+
+@pytest.mark.parametrize("synthetic_waterfall", ["psrfits_fold"], indirect=True)
+def test_folded_psrfits_uses_phase_bins_as_pseudo_time(synthetic_waterfall):
+    inspection = inspect_filterbank(synthetic_waterfall.path)
+    assert inspection.schema_version == "psrfits_fold"
+
+    config = ObservationConfig.from_preset(dm=0.0, preset_key="generic", sefd_jy=1.0)
+    data, metadata = load_filterbank_data(synthetic_waterfall.path, config, inspection=inspection)
+
+    assert data.shape == synthetic_waterfall.data.shape
+    assert metadata.tsamp == pytest.approx(synthetic_waterfall.tsamp_s, rel=1e-6)
+    assert metadata.freqres == pytest.approx(abs(synthetic_waterfall.foff_mhz), rel=1e-6)
+    assert metadata.bandwidth_mhz == pytest.approx(
+        abs(synthetic_waterfall.foff_mhz) * synthetic_waterfall.data.shape[0],
+        rel=1e-6,
+    )
+    assert int(np.argmax(data.mean(axis=0))) == pytest.approx(synthetic_waterfall.burst_time_idx, abs=5)
 
 
 @pytest.mark.parametrize("synthetic_waterfall", ["sigproc"], indirect=True)

--- a/tests/test_session_io_smoke.py
+++ b/tests/test_session_io_smoke.py
@@ -12,7 +12,7 @@ import pytest
 from flits.session import BurstSession
 
 
-_ALL_FORMATS = ["sigproc", "chime_hdf5", "psrfits", "chime_bbdata_beamformed"]
+_ALL_FORMATS = ["sigproc", "chime_hdf5", "psrfits", "psrfits_fold", "chime_bbdata_beamformed"]
 
 
 @pytest.mark.parametrize("synthetic_waterfall", _ALL_FORMATS, indirect=True)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 
 import h5py
 import numpy as np
+import pytest
 from fastapi import HTTPException
 
 from flits.io.filterbank import FilterbankInspection, your
@@ -49,6 +50,12 @@ from flits.web.app import (
 ROOT = Path(__file__).resolve().parents[1]
 SAMPLE = ROOT / "blc_s_guppi_60385_53711_DIAG_FRB20240114A_0057_40.265_41.518_b32_I0_D527_851_F192D_K_t30_d1.fil"
 DM_CONST = 1 / (2.41 * 10 ** -4)
+
+
+@pytest.mark.parametrize("synthetic_waterfall", ["psrfits_fold"], indirect=True)
+def test_listing_includes_folded_psrfits(synthetic_waterfall) -> None:
+    with patch.dict("os.environ", {"FLITS_DATA_DIR": str(synthetic_waterfall.path.parent)}):
+        assert synthetic_waterfall.path.name in list_filterbank_files()
 
 
 def _synthetic_session(*, auto_mask_profile: str = "auto") -> BurstSession:


### PR DESCRIPTION
Feature: Compatible with Folded Pulsar `.fits`

See issue [here](https://github.com/DirkKuiper/flits/issues/62). I want to treat folded pulsar data as a single pulse dynamic spectra with a psuedo-time axis (from the phase bins), so we can use the `fitburst` functionality of `flits`

I have edited the `Dockerfile` to install `psrchive`, and use that to read in the folded pulsar data in `flits/io/your_reader.py`. I think I have succeeded in finding and reading in the folded `.fits` files, but I'm unsure on how to fully integrate this into the rest of the package --- I'm running into hard to debug errors at this stage. 

-Max 